### PR TITLE
chore: align local setup and mint scripts

### DIFF
--- a/scripts/mint.sh
+++ b/scripts/mint.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -e  # Stop script on errors
 
-echo Mint $2 KINIC to $1
+MINTER_NAME="${3:-local-minter}"
+
+echo Mint $2 KINIC to $1 using identity ${MINTER_NAME}
 KINIC=$(( $2 * 100000000 ))
 
-dfx --identity default canister call 73mez-iiaaa-aaaaq-aaasq-cai icrc1_transfer '
+dfx --identity "${MINTER_NAME}" canister call 73mez-iiaaa-aaaaq-aaasq-cai icrc1_transfer '
 (
   record {
     25_979 = record {
@@ -18,4 +20,3 @@ dfx --identity default canister call 73mez-iiaaa-aaaaq-aaasq-cai icrc1_transfer 
     3_573_748_184 = '$KINIC' : nat;
   },
 )'
-

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,17 +5,22 @@ set -o pipefail  # Fail on pipeline errors
 
 ## -- Ledger --
 USER_NAME=$(dfx identity whoami)
+USER_PRINCIPAL=$(dfx identity get-principal)
+MINTER_NAME="${KINIC_LOCAL_MINTER_IDENTITY:-local-minter}"
 echo "Current user: ${USER_NAME}"
 
-dfx identity use default 
+if ! dfx identity use "${MINTER_NAME}" >/dev/null 2>&1; then
+  dfx identity new "${MINTER_NAME}" --storage-mode plaintext --disable-encryption >/dev/null
+  dfx identity use "${MINTER_NAME}" >/dev/null
+fi
 
 # Set environment variables
-export DEFAULT=$(dfx identity get-principal)
+export MINTER_PRINCIPAL=$(dfx identity get-principal)
 export TOKEN_NAME="My Token"
 export TOKEN_SYMBOL="XMTK"
 export PRE_MINTED_TOKENS=10_000_000_000
 export TRANSFER_FEE=100_000
-export ARCHIVE_CONTROLLER=$(dfx identity get-principal)
+export ARCHIVE_CONTROLLER="${MINTER_PRINCIPAL}"
 export TRIGGER_THRESHOLD=2000
 export NUM_OF_BLOCK_TO_ARCHIVE=1000
 export CYCLE_FOR_ARCHIVE_CREATION=10000000000000
@@ -26,11 +31,11 @@ dfx deploy icrc1_ledger_canister --specified-id 73mez-iiaaa-aaaaq-aaasq-cai --ar
 record {
      token_symbol = \"${TOKEN_SYMBOL}\";
      token_name = \"${TOKEN_NAME}\";
-     minting_account = record { owner = principal \"${DEFAULT}\" };
+     minting_account = record { owner = principal \"${MINTER_PRINCIPAL}\" };
      transfer_fee = ${TRANSFER_FEE};
      metadata = vec {};
      feature_flags = opt record{icrc2 = ${FEATURE_FLAGS}};
-     initial_balances = vec { record { record { owner = principal \"${DEFAULT}\"; }; ${PRE_MINTED_TOKENS}; }; };
+     initial_balances = vec { record { record { owner = principal \"${USER_PRINCIPAL}\"; }; ${PRE_MINTED_TOKENS}; }; };
      archive_options = record {
          num_blocks_to_archive = ${NUM_OF_BLOCK_TO_ARCHIVE};
          trigger_threshold = ${TRIGGER_THRESHOLD};
@@ -51,5 +56,4 @@ dfx ledger fabricate-cycles --cycles 100T --canister $(dfx canister id launcher)
 
 dfx identity use $USER_NAME
 
-sh scripts/mint.sh $(dfx identity get-principal) 100
-
+bash scripts/mint.sh "${USER_PRINCIPAL}" 100 "${MINTER_NAME}"


### PR DESCRIPTION
## Summary
- update local setup and mint scripts to use the dedicated local minter identity consistently
- keep the script change separate from the runtime foundation and memory-create PRs

## Validation
- cargo test (in tui/)
- cargo clippy --all-targets --all-features -- -D warnings (in tui/)