### PR TITLE
Add file picker support for insert flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle 0.6.2",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +155,61 @@ dependencies = [
  "concurrent-queue",
  "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,6 +222,70 @@ dependencies = [
  "event-listener-strategy",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.2",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -307,6 +460,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -773,6 +948,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,10 +971,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "ecdsa"
@@ -878,6 +1080,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -1040,6 +1269,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1427,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1338,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5337598ec943bab711e0288319761abb5a7a7087ac226b03472441a90f88e0c"
 dependencies = [
  "arc-swap",
- "async-channel",
+ "async-channel 1.9.0",
  "async-lock",
  "async-trait",
  "async-watch",
@@ -1844,6 +2092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2369,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2497,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "p256"
@@ -2310,6 +2627,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2652,26 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "pom"
@@ -2385,6 +2733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2465,6 +2822,15 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2630,6 +2996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,6 +3071,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle 0.6.2",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,6 +3207,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3133,7 +3535,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "cfg-if",
  "futures-core",
  "pin-project-lite",
@@ -3395,6 +3797,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db3bae107c9522f86d361697dee1d7386a2ddcf659d5aea5159819a21a3c4a7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+dependencies = [
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3943,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "ratatui",
+ "rfd",
  "serde",
  "serde_yaml",
  "tui-kit-render",
@@ -3563,6 +3996,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3639,6 +4083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3649,6 +4099,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3774,6 +4235,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.2",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix 1.1.2",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,7 +4326,7 @@ dependencies = [
  "log",
  "ndk-context",
  "objc",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "url",
  "web-sys",
 ]
@@ -4094,6 +4615,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4665,67 @@ dependencies = [
  "quote",
  "syn 2.0.109",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.2",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
 ]
 
 [[package]]
@@ -4220,4 +4820,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.109",
+ "winnow 0.7.15",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ring = "0.17.14"
 der = "0.7.10"
 pkcs8 = "0.10.2"
 ic-ed25519 = "0.2.0"
-tui-kit-host = { path = "tui/crates/tui-kit-host" }
+tui-kit-host = { path = "tui/crates/tui-kit-host", features = ["rfd-file-picker"] }
 tui-kit-runtime = { path = "tui/crates/tui-kit-runtime" }
 tui-kit-model = { path = "tui/crates/tui-kit-model" }
 tui-kit-render = { path = "tui/crates/tui-kit-render" }

--- a/rust/tui/mod.rs
+++ b/rust/tui/mod.rs
@@ -26,6 +26,7 @@ mod ui_config;
 use tui_kit_host::{
     execute_effects_to_status,
     runtime_loop::{RuntimeLoopConfig, RuntimeLoopHooks, run_provider_app_with_hooks},
+    terminal::rfd_file_picker,
 };
 use tui_kit_runtime::{
     CoreState, CreateCostState, CreateSubmitState, DataProvider, PaneFocus, apply_snapshot,
@@ -148,6 +149,7 @@ fn kinic_runtime_loop_config() -> RuntimeLoopConfig {
         tab_ids: &kinic_tabs::KINIC_TAB_IDS,
         initial_focus: PaneFocus::Search,
         ui_config: ui_config::kinic_ui_config,
+        file_picker: Some(rfd_file_picker),
     }
 }
 

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -116,6 +116,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle 0.6.2",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +158,61 @@ dependencies = [
  "concurrent-queue",
  "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -136,6 +225,70 @@ dependencies = [
  "event-listener-strategy",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -310,6 +463,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -808,6 +983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,10 +1006,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "ecdsa"
@@ -913,6 +1115,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1079,6 +1308,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1259,6 +1501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5337598ec943bab711e0288319761abb5a7a7087ac226b03472441a90f88e0c"
 dependencies = [
  "arc-swap",
- "async-channel",
+ "async-channel 1.9.0",
  "async-lock",
  "async-trait",
  "async-watch",
@@ -1966,6 +2214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2344,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "merlin"
@@ -2241,6 +2508,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,6 +2642,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "p256"
@@ -2458,6 +2784,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2809,26 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "pom"
@@ -2540,6 +2897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.9+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2922,15 @@ checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2610,7 +2985,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2727,6 +3102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +3183,30 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle 0.6.2",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2923,6 +3328,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3258,7 +3669,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "cfg-if",
  "futures-core",
  "pin-project-lite",
@@ -3552,8 +3963,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3566,6 +3977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,9 +3994,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3712,6 +4153,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "ratatui",
+ "rfd",
  "serde",
  "serde_yaml",
  "tui-kit-render",
@@ -3764,6 +4206,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3837,7 +4290,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3850,6 +4310,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -4019,6 +4490,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4050,7 +4581,7 @@ dependencies = [
  "log",
  "ndk-context",
  "objc",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "url",
  "web-sys",
 ]
@@ -4377,6 +4908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,6 +5034,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,3 +5193,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -41,7 +41,7 @@ test = false
 clap = { version = "4.5.51", features = ["derive"] }
 kinic_core = { package = "kinic-cli", path = ".." }
 tokio = { version = "1.48", features = ["rt-multi-thread"] }
-tui-kit-host = { path = "crates/tui-kit-host" }
+tui-kit-host = { path = "crates/tui-kit-host", features = ["rfd-file-picker"] }
 tui-kit-runtime = { path = "crates/tui-kit-runtime" }
 tui-kit-model = { path = "crates/tui-kit-model" }
 tui-kit-render = { path = "crates/tui-kit-render" }

--- a/tui/crates/tui-kit-host/Cargo.toml
+++ b/tui/crates/tui-kit-host/Cargo.toml
@@ -17,5 +17,6 @@ dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 ratatui = "0.29"
+rfd = "0.15"
 tui-kit-render = { path = "../tui-kit-render" }
 tui-kit-runtime = { path = "../tui-kit-runtime" }

--- a/tui/crates/tui-kit-host/Cargo.toml
+++ b/tui/crates/tui-kit-host/Cargo.toml
@@ -10,6 +10,10 @@ description = "Host-side utilities for tui-kit runtime integration"
 name = "tui_kit_host"
 path = "src/lib.rs"
 
+[features]
+default = []
+rfd-file-picker = ["dep:rfd"]
+
 [dependencies]
 crossterm = "0.28"
 webbrowser = "0.8"
@@ -17,6 +21,6 @@ dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 ratatui = "0.29"
-rfd = "0.15"
+rfd = { version = "0.15", optional = true }
 tui-kit-render = { path = "../tui-kit-render" }
 tui-kit-runtime = { path = "../tui-kit-runtime" }

--- a/tui/crates/tui-kit-host/src/form_tab_flow.rs
+++ b/tui/crates/tui-kit-host/src/form_tab_flow.rs
@@ -42,6 +42,7 @@ pub fn form_tab_action_from_key(code: KeyCode, state: &mut CoreState) -> Option<
         KeyCode::Enter => match state.insert_focus {
             InsertFormFocus::Mode => Some(CoreAction::InsertCycleMode),
             InsertFormFocus::MemoryId => Some(CoreAction::OpenDefaultMemoryPicker),
+            InsertFormFocus::FilePath => Some(CoreAction::InsertOpenFileDialog),
             InsertFormFocus::Submit => Some(CoreAction::InsertSubmit),
             _ => None,
         },

--- a/tui/crates/tui-kit-host/src/form_tab_flow.rs
+++ b/tui/crates/tui-kit-host/src/form_tab_flow.rs
@@ -75,7 +75,8 @@ pub fn reset_form_state_for_tab(state: &mut CoreState, tab_id: &str) {
         state.insert_memory_id = state.saved_default_memory_id.clone().unwrap_or_default();
         state.insert_tag.clear();
         state.insert_text.clear();
-        state.insert_file_path.clear();
+        state.insert_file_path_input.clear();
+        state.insert_selected_file_path = None;
         state.insert_embedding.clear();
         state.insert_submit_state = tui_kit_runtime::CreateSubmitState::Idle;
         state.insert_spinner_frame = 0;

--- a/tui/crates/tui-kit-host/src/form_tab_flow_tests.rs
+++ b/tui/crates/tui-kit-host/src/form_tab_flow_tests.rs
@@ -146,7 +146,8 @@ fn reset_insert_form_state_clears_insert_fields() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: "/tmp/doc.pdf".to_string(),
+        insert_file_path_input: "/tmp/doc.pdf".to_string(),
+        insert_selected_file_path: Some(std::path::PathBuf::from("/tmp/doc.pdf")),
         insert_submit_state: tui_kit_runtime::CreateSubmitState::Submitting,
         insert_error: Some("boom".to_string()),
         insert_focus: InsertFormFocus::Submit,
@@ -158,7 +159,8 @@ fn reset_insert_form_state_clears_insert_fields() {
     assert_eq!(state.insert_mode, InsertMode::File);
     assert_eq!(state.insert_memory_id, "bbbbb-bb");
     assert_eq!(state.insert_tag, "");
-    assert_eq!(state.insert_file_path, "");
+    assert_eq!(state.insert_file_path_input, "");
+    assert_eq!(state.insert_selected_file_path, None);
     assert_eq!(state.insert_error, None);
     assert_eq!(state.insert_focus, InsertFormFocus::Mode);
 }

--- a/tui/crates/tui-kit-host/src/form_tab_flow_tests.rs
+++ b/tui/crates/tui-kit-host/src/form_tab_flow_tests.rs
@@ -126,6 +126,20 @@ fn insert_submit_focus_uses_enter_to_submit() {
 }
 
 #[test]
+fn insert_file_path_focus_uses_enter_to_open_file_dialog() {
+    let mut state = CoreState {
+        current_tab_id: KINIC_INSERT_TAB_ID.to_string(),
+        focus: PaneFocus::Form,
+        insert_focus: InsertFormFocus::FilePath,
+        ..CoreState::default()
+    };
+
+    let action = form_tab_action_from_key(KeyCode::Enter, &mut state);
+
+    assert_eq!(action, Some(CoreAction::InsertOpenFileDialog));
+}
+
+#[test]
 fn reset_insert_form_state_clears_insert_fields() {
     let mut state = CoreState {
         saved_default_memory_id: Some("bbbbb-bb".to_string()),

--- a/tui/crates/tui-kit-host/src/lib.rs
+++ b/tui/crates/tui-kit-host/src/lib.rs
@@ -344,7 +344,8 @@ pub fn execute_effects_to_status(state: &mut CoreState, effects: Vec<CoreEffect>
             }
             CoreEffect::ResetInsertFormForRepeat => {
                 state.insert_text.clear();
-                state.insert_file_path.clear();
+                state.insert_file_path_input.clear();
+                state.insert_selected_file_path = None;
                 state.insert_embedding.clear();
                 state.insert_submit_state = CreateSubmitState::Idle;
                 state.insert_spinner_frame = 0;

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -16,7 +16,7 @@ use tui_kit_runtime::{
 use crate::{
     HostGlobalCommand, HostInputEvent, action_from_keycode, execute_effects_to_status,
     global_command_for_key, poll_host_input, resolve_tab_action_with_current,
-    terminal::with_terminal,
+    terminal::{pick_file_path, with_terminal},
 };
 use form_tab_flow::{form_tab_action_from_key, reset_form_focus, reset_form_state_for_tab};
 
@@ -353,6 +353,13 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                         | CoreAction::MovePageUp
                         | CoreAction::OpenSelected
                 );
+                if matches!(action, CoreAction::InsertOpenFileDialog) {
+                    match open_insert_file_dialog(&mut state, terminal) {
+                        Ok(()) => {}
+                        Err(error) => state.status_message = Some(error),
+                    }
+                    continue;
+                }
                 match dispatch_action_with_persistent_clear(provider, &mut state, &action) {
                     Ok(effects) => {
                         if matches!(&action, CoreAction::SetTab(_)) {
@@ -378,6 +385,32 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             }
         }
     })
+}
+
+fn open_insert_file_dialog(
+    state: &mut CoreState,
+    terminal: &mut crate::terminal::HostTerminal,
+) -> Result<(), String> {
+    let selection = pick_file_path(terminal, state.insert_mode)?;
+    apply_insert_file_dialog_selection(state, selection);
+    Ok(())
+}
+
+fn apply_insert_file_dialog_selection(
+    state: &mut CoreState,
+    selection: Option<std::path::PathBuf>,
+) {
+    let Some(path) = selection else {
+        state.status_message = Some("File selection canceled.".to_string());
+        return;
+    };
+
+    state.insert_file_path = path.to_string_lossy().into_owned();
+    state.insert_error = None;
+    if state.insert_submit_state == tui_kit_runtime::CreateSubmitState::Error {
+        state.insert_submit_state = tui_kit_runtime::CreateSubmitState::Idle;
+    }
+    state.status_message = Some(format!("Selected file: {}", path.display()));
 }
 
 fn normalize_focus_after_set_tab(state: &mut CoreState) {

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -1,7 +1,7 @@
 #[path = "form_tab_flow.rs"]
 mod form_tab_flow;
 
-use std::time::Duration;
+use std::{io, time::Duration};
 use tui_kit_render::theme::Theme;
 use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
 use tui_kit_render::ui::{AnimationState, Focus, TabId, TuiKitUi, UiConfig};
@@ -16,7 +16,7 @@ use tui_kit_runtime::{
 use crate::{
     HostGlobalCommand, HostInputEvent, action_from_keycode, execute_effects_to_status,
     global_command_for_key, poll_host_input, resolve_tab_action_with_current,
-    terminal::{pick_file_path, with_terminal},
+    terminal::{FilePickerFn, PickFilePathError, pick_file_path, with_terminal},
 };
 use form_tab_flow::{form_tab_action_from_key, reset_form_focus, reset_form_state_for_tab};
 
@@ -25,6 +25,7 @@ pub struct RuntimeLoopConfig {
     pub tab_ids: &'static [&'static str],
     pub initial_focus: PaneFocus,
     pub ui_config: fn() -> UiConfig,
+    pub file_picker: Option<FilePickerFn>,
 }
 
 pub trait RuntimeLoopHooks<P: DataProvider> {
@@ -114,6 +115,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
 
             terminal.draw(|frame| {
                 let focus = ui_focus_from_pane(state.focus);
+                let insert_file_path_display = insert_file_path_display(&state);
                 let ui = TuiKitUi::new(&theme)
                     .ui_config((cfg.ui_config)())
                     .ui_summaries(&state.list_items)
@@ -148,7 +150,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                     .insert_memory_placeholder(state.insert_memory_placeholder.as_deref())
                     .insert_tag(&state.insert_tag)
                     .insert_text(&state.insert_text)
-                    .insert_file_path(&state.insert_file_path)
+                    .insert_file_path(insert_file_path_display.as_str())
                     .insert_embedding(&state.insert_embedding)
                     .insert_submit_state(state.insert_submit_state.clone())
                     .insert_spinner_frame(state.insert_spinner_frame)
@@ -354,9 +356,20 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                         | CoreAction::OpenSelected
                 );
                 if should_open_insert_file_dialog(&action, &state) {
-                    match open_insert_file_dialog(&mut state, terminal) {
-                        Ok(()) => {}
-                        Err(error) => state.status_message = Some(error),
+                    match open_insert_file_dialog(&mut state, terminal, cfg.file_picker) {
+                        Ok(effects) => {
+                            hooks.on_effects(provider, &mut state, &effects);
+                            execute_effects_to_status(&mut state, effects);
+                        }
+                        Err(PickFilePathError::Picker(error)) => {
+                            execute_effects_to_status(
+                                &mut state,
+                                vec![CoreEffect::Notify(error)],
+                            );
+                        }
+                        Err(PickFilePathError::TerminalState(error)) => {
+                            return Err(Box::new(io::Error::other(error)));
+                        }
                     }
                     continue;
                 }
@@ -390,27 +403,41 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
 fn open_insert_file_dialog(
     state: &mut CoreState,
     terminal: &mut crate::terminal::HostTerminal,
-) -> Result<(), String> {
-    let selection = pick_file_path(terminal, state.insert_mode)?;
-    apply_insert_file_dialog_selection(state, selection);
-    Ok(())
+    file_picker: Option<FilePickerFn>,
+) -> Result<Vec<CoreEffect>, PickFilePathError> {
+    let Some(file_picker) = file_picker else {
+        return Ok(vec![CoreEffect::Notify(
+            "File picker is unavailable in this build.".to_string(),
+        )]);
+    };
+    let selection = pick_file_path(terminal, file_picker, state.insert_mode)?;
+    Ok(apply_insert_file_dialog_selection(state, selection))
 }
 
 fn apply_insert_file_dialog_selection(
     state: &mut CoreState,
     selection: Option<std::path::PathBuf>,
-) {
+) -> Vec<CoreEffect> {
     let Some(path) = selection else {
-        state.status_message = Some("File selection canceled.".to_string());
-        return;
+        return vec![CoreEffect::Notify("File selection canceled.".to_string())];
     };
 
-    state.insert_file_path = path.to_string_lossy().into_owned();
+    let display_path = path.display().to_string();
+    state.insert_file_path_input = display_path.clone();
+    state.insert_selected_file_path = Some(path);
     state.insert_error = None;
     if state.insert_submit_state == tui_kit_runtime::CreateSubmitState::Error {
         state.insert_submit_state = tui_kit_runtime::CreateSubmitState::Idle;
     }
-    state.status_message = Some(format!("Selected file: {}", path.display()));
+    vec![CoreEffect::Notify(format!("Selected file: {display_path}"))]
+}
+
+fn insert_file_path_display(state: &CoreState) -> String {
+    state
+        .insert_selected_file_path
+        .as_ref()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| state.insert_file_path_input.clone())
 }
 
 fn should_open_insert_file_dialog(action: &CoreAction, state: &CoreState) -> bool {

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -7,7 +7,7 @@ use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
 use tui_kit_render::ui::{AnimationState, Focus, TabId, TuiKitUi, UiConfig};
 use tui_kit_runtime::{
     CoreAction, CoreEffect, CoreState, DataProvider, PaneFocus, apply_snapshot, dispatch_action,
-    kinic_tabs::{
+    is_insert_form_locked, kinic_tabs::{
         KINIC_CREATE_TAB_ID, KINIC_MEMORIES_TAB_ID, KINIC_SETTINGS_TAB_ID, TabKind, tab_kind,
     },
     should_open_default_memory_picker,
@@ -353,7 +353,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                         | CoreAction::MovePageUp
                         | CoreAction::OpenSelected
                 );
-                if matches!(action, CoreAction::InsertOpenFileDialog) {
+                if should_open_insert_file_dialog(&action, &state) {
                     match open_insert_file_dialog(&mut state, terminal) {
                         Ok(()) => {}
                         Err(error) => state.status_message = Some(error),
@@ -411,6 +411,10 @@ fn apply_insert_file_dialog_selection(
         state.insert_submit_state = tui_kit_runtime::CreateSubmitState::Idle;
     }
     state.status_message = Some(format!("Selected file: {}", path.display()));
+}
+
+fn should_open_insert_file_dialog(action: &CoreAction, state: &CoreState) -> bool {
+    matches!(action, CoreAction::InsertOpenFileDialog) && !is_insert_form_locked(state)
 }
 
 fn normalize_focus_after_set_tab(state: &mut CoreState) {

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -391,3 +391,22 @@ fn apply_insert_file_dialog_selection_keeps_existing_path_on_cancel() {
         Some("File selection canceled.")
     );
 }
+
+#[test]
+fn should_open_insert_file_dialog_is_false_while_insert_submit_is_in_flight() {
+    let state = CoreState {
+        insert_submit_state: tui_kit_runtime::CreateSubmitState::Submitting,
+        insert_file_path: "/tmp/existing.md".into(),
+        insert_error: Some("keep".into()),
+        status_message: Some("ready".into()),
+        ..CoreState::default()
+    };
+
+    assert!(!should_open_insert_file_dialog(
+        &CoreAction::InsertOpenFileDialog,
+        &state
+    ));
+    assert_eq!(state.insert_file_path, "/tmp/existing.md");
+    assert_eq!(state.insert_error.as_deref(), Some("keep"));
+    assert_eq!(state.status_message.as_deref(), Some("ready"));
+}

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::PathBuf;
 use tui_kit_runtime::kinic_tabs::{
     KINIC_CREATE_TAB_ID, KINIC_INSERT_TAB_ID, KINIC_MARKET_TAB_ID, KINIC_MEMORIES_TAB_ID,
 };
@@ -350,4 +351,43 @@ fn dispatch_action_with_persistent_clear_keeps_for_navigation_actions() {
     assert!(effects.is_empty());
     assert_eq!(state.persistent_status_message.as_deref(), Some("done"));
     assert_eq!(state.status_message.as_deref(), Some("done"));
+}
+
+#[test]
+fn apply_insert_file_dialog_selection_updates_file_path_and_clears_insert_error() {
+    let mut state = CoreState {
+        insert_file_path: "stale".into(),
+        insert_error: Some("bad path".into()),
+        insert_submit_state: tui_kit_runtime::CreateSubmitState::Error,
+        ..CoreState::default()
+    };
+
+    apply_insert_file_dialog_selection(&mut state, Some(PathBuf::from("/tmp/doc.pdf")));
+
+    assert_eq!(state.insert_file_path, "/tmp/doc.pdf");
+    assert_eq!(state.insert_error, None);
+    assert_eq!(
+        state.insert_submit_state,
+        tui_kit_runtime::CreateSubmitState::Idle
+    );
+    assert_eq!(
+        state.status_message.as_deref(),
+        Some("Selected file: /tmp/doc.pdf")
+    );
+}
+
+#[test]
+fn apply_insert_file_dialog_selection_keeps_existing_path_on_cancel() {
+    let mut state = CoreState {
+        insert_file_path: "/tmp/existing.md".into(),
+        ..CoreState::default()
+    };
+
+    apply_insert_file_dialog_selection(&mut state, None);
+
+    assert_eq!(state.insert_file_path, "/tmp/existing.md");
+    assert_eq!(
+        state.status_message.as_deref(),
+        Some("File selection canceled.")
+    );
 }

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -181,7 +181,7 @@ fn open_insert_tab_failure_keeps_insert_form_state_and_focus() {
         insert_mode: tui_kit_runtime::InsertMode::File,
         insert_memory_id: "aaaaa-aa".into(),
         insert_tag: "docs".into(),
-        insert_file_path: "/tmp/doc.pdf".into(),
+        insert_file_path_input: "/tmp/doc.pdf".into(),
         insert_focus: tui_kit_runtime::InsertFormFocus::Submit,
         status_message: Some("ready".into()),
         ..CoreState::default()
@@ -199,7 +199,7 @@ fn open_insert_tab_failure_keeps_insert_form_state_and_focus() {
     assert_eq!(state.insert_mode, tui_kit_runtime::InsertMode::File);
     assert_eq!(state.insert_memory_id, "aaaaa-aa");
     assert_eq!(state.insert_tag, "docs");
-    assert_eq!(state.insert_file_path, "/tmp/doc.pdf");
+    assert_eq!(state.insert_file_path_input, "/tmp/doc.pdf");
     assert_eq!(state.insert_focus, tui_kit_runtime::InsertFormFocus::Submit);
     assert_eq!(
         state.status_message.as_deref(),
@@ -356,39 +356,46 @@ fn dispatch_action_with_persistent_clear_keeps_for_navigation_actions() {
 #[test]
 fn apply_insert_file_dialog_selection_updates_file_path_and_clears_insert_error() {
     let mut state = CoreState {
-        insert_file_path: "stale".into(),
+        insert_file_path_input: "stale".into(),
         insert_error: Some("bad path".into()),
         insert_submit_state: tui_kit_runtime::CreateSubmitState::Error,
         ..CoreState::default()
     };
 
-    apply_insert_file_dialog_selection(&mut state, Some(PathBuf::from("/tmp/doc.pdf")));
+    let effects = apply_insert_file_dialog_selection(&mut state, Some(PathBuf::from("/tmp/doc.pdf")));
 
-    assert_eq!(state.insert_file_path, "/tmp/doc.pdf");
+    assert_eq!(state.insert_file_path_input, "/tmp/doc.pdf");
+    assert_eq!(
+        state.insert_selected_file_path,
+        Some(PathBuf::from("/tmp/doc.pdf"))
+    );
     assert_eq!(state.insert_error, None);
     assert_eq!(
         state.insert_submit_state,
         tui_kit_runtime::CreateSubmitState::Idle
     );
     assert_eq!(
-        state.status_message.as_deref(),
-        Some("Selected file: /tmp/doc.pdf")
+        effects,
+        vec![CoreEffect::Notify("Selected file: /tmp/doc.pdf".to_string())]
     );
 }
 
 #[test]
 fn apply_insert_file_dialog_selection_keeps_existing_path_on_cancel() {
     let mut state = CoreState {
-        insert_file_path: "/tmp/existing.md".into(),
+        insert_selected_file_path: Some(PathBuf::from("/tmp/existing.md")),
         ..CoreState::default()
     };
 
-    apply_insert_file_dialog_selection(&mut state, None);
+    let effects = apply_insert_file_dialog_selection(&mut state, None);
 
-    assert_eq!(state.insert_file_path, "/tmp/existing.md");
     assert_eq!(
-        state.status_message.as_deref(),
-        Some("File selection canceled.")
+        state.insert_selected_file_path,
+        Some(PathBuf::from("/tmp/existing.md"))
+    );
+    assert_eq!(
+        effects,
+        vec![CoreEffect::Notify("File selection canceled.".to_string())]
     );
 }
 
@@ -396,7 +403,7 @@ fn apply_insert_file_dialog_selection_keeps_existing_path_on_cancel() {
 fn should_open_insert_file_dialog_is_false_while_insert_submit_is_in_flight() {
     let state = CoreState {
         insert_submit_state: tui_kit_runtime::CreateSubmitState::Submitting,
-        insert_file_path: "/tmp/existing.md".into(),
+        insert_file_path_input: "/tmp/existing.md".into(),
         insert_error: Some("keep".into()),
         status_message: Some("ready".into()),
         ..CoreState::default()
@@ -406,7 +413,7 @@ fn should_open_insert_file_dialog_is_false_while_insert_submit_is_in_flight() {
         &CoreAction::InsertOpenFileDialog,
         &state
     ));
-    assert_eq!(state.insert_file_path, "/tmp/existing.md");
+    assert_eq!(state.insert_file_path_input, "/tmp/existing.md");
     assert_eq!(state.insert_error.as_deref(), Some("keep"));
     assert_eq!(state.status_message.as_deref(), Some("ready"));
 }

--- a/tui/crates/tui-kit-host/src/terminal.rs
+++ b/tui/crates/tui-kit-host/src/terminal.rs
@@ -6,28 +6,58 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
+use rfd::FileDialog;
+use tui_kit_runtime::InsertMode;
 
 pub type HostTerminal = Terminal<CrosstermBackend<io::Stdout>>;
 
-pub fn with_terminal<R, F>(run: F) -> Result<R, Box<dyn std::error::Error>>
-where
-    F: FnOnce(&mut HostTerminal) -> Result<R, Box<dyn std::error::Error>>,
-{
+fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<()> {
     enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
+    execute!(
+        terminal.backend_mut(),
+        EnterAlternateScreen,
+        EnableMouseCapture
+    )?;
+    terminal.hide_cursor()?;
+    Ok(())
+}
 
-    let result = run(&mut terminal);
-
+fn leave_terminal(terminal: &mut HostTerminal) -> io::Result<()> {
+    terminal.show_cursor()?;
     disable_raw_mode()?;
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
         DisableMouseCapture
     )?;
-    terminal.show_cursor()?;
+    Ok(())
+}
+
+pub fn with_terminal<R, F>(run: F) -> Result<R, Box<dyn std::error::Error>>
+where
+    F: FnOnce(&mut HostTerminal) -> Result<R, Box<dyn std::error::Error>>,
+{
+    let stdout = io::stdout();
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    enter_terminal(&mut terminal)?;
+
+    let result = run(&mut terminal);
+
+    leave_terminal(&mut terminal)?;
 
     result
+}
+
+pub fn pick_file_path(
+    terminal: &mut HostTerminal,
+    _insert_mode: InsertMode,
+) -> Result<Option<std::path::PathBuf>, String> {
+    leave_terminal(terminal).map_err(|error| error.to_string())?;
+
+    let selection = FileDialog::new().set_title("Select file").pick_file();
+
+    enter_terminal(terminal).map_err(|error| error.to_string())?;
+    terminal.clear().map_err(|error| error.to_string())?;
+    Ok(selection)
 }

--- a/tui/crates/tui-kit-host/src/terminal.rs
+++ b/tui/crates/tui-kit-host/src/terminal.rs
@@ -1,4 +1,9 @@
-use std::io;
+//! Terminal enter/leave helpers for host loops and GUI picker suspension.
+//!
+//! This module keeps terminal restoration explicit so GUI dialogs cannot leave
+//! the host loop in a half-restored state.
+
+use std::{fmt, io, path::PathBuf};
 
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
@@ -6,10 +11,29 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
-use rfd::FileDialog;
 use tui_kit_runtime::InsertMode;
 
+#[cfg(feature = "rfd-file-picker")]
+use tui_kit_runtime::FILE_MODE_ALLOWED_EXTENSIONS;
+
 pub type HostTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+pub type FilePickerFn = fn(InsertMode) -> Result<Option<PathBuf>, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PickFilePathError {
+    Picker(String),
+    TerminalState(String),
+}
+
+impl fmt::Display for PickFilePathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Picker(message) | Self::TerminalState(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for PickFilePathError {}
 
 fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<()> {
     enable_raw_mode()?;
@@ -33,6 +57,41 @@ fn leave_terminal(terminal: &mut HostTerminal) -> io::Result<()> {
     Ok(())
 }
 
+struct SuspendedTerminal<'a> {
+    terminal: &'a mut HostTerminal,
+    suspended: bool,
+}
+
+impl<'a> SuspendedTerminal<'a> {
+    fn new(terminal: &'a mut HostTerminal) -> Result<Self, PickFilePathError> {
+        leave_terminal(terminal)
+            .map_err(|error| PickFilePathError::TerminalState(error.to_string()))?;
+        Ok(Self {
+            terminal,
+            suspended: true,
+        })
+    }
+
+    fn restore(&mut self) -> Result<(), PickFilePathError> {
+        enter_terminal(self.terminal)
+            .map_err(|error| PickFilePathError::TerminalState(error.to_string()))?;
+        self.terminal
+            .clear()
+            .map_err(|error| PickFilePathError::TerminalState(error.to_string()))?;
+        self.suspended = false;
+        Ok(())
+    }
+}
+
+impl Drop for SuspendedTerminal<'_> {
+    fn drop(&mut self) {
+        if self.suspended {
+            let _ = enter_terminal(self.terminal);
+            let _ = self.terminal.clear();
+        }
+    }
+}
+
 pub fn with_terminal<R, F>(run: F) -> Result<R, Box<dyn std::error::Error>>
 where
     F: FnOnce(&mut HostTerminal) -> Result<R, Box<dyn std::error::Error>>,
@@ -43,21 +102,190 @@ where
     enter_terminal(&mut terminal)?;
 
     let result = run(&mut terminal);
+    let cleanup = leave_terminal(&mut terminal);
 
-    leave_terminal(&mut terminal)?;
-
-    result
+    match (result, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(Box::new(error)),
+        (Err(run_error), Err(_cleanup_error)) => Err(run_error),
+    }
 }
 
 pub fn pick_file_path(
     terminal: &mut HostTerminal,
-    _insert_mode: InsertMode,
-) -> Result<Option<std::path::PathBuf>, String> {
-    leave_terminal(terminal).map_err(|error| error.to_string())?;
+    picker: FilePickerFn,
+    insert_mode: InsertMode,
+) -> Result<Option<PathBuf>, PickFilePathError> {
+    let mut suspended = SuspendedTerminal::new(terminal)?;
+    match picker(insert_mode) {
+        Ok(selection) => {
+            suspended.restore()?;
+            Ok(selection)
+        }
+        Err(error) => match suspended.restore() {
+            Ok(()) => Err(PickFilePathError::Picker(error)),
+            Err(restore_error) => Err(restore_error),
+        },
+    }
+}
 
-    let selection = FileDialog::new().set_title("Select file").pick_file();
+#[cfg(feature = "rfd-file-picker")]
+pub fn rfd_file_picker(insert_mode: InsertMode) -> Result<Option<PathBuf>, String> {
+    use rfd::FileDialog;
 
-    enter_terminal(terminal).map_err(|error| error.to_string())?;
-    terminal.clear().map_err(|error| error.to_string())?;
-    Ok(selection)
+    let mut dialog = FileDialog::new().set_title("Select file");
+    if matches!(insert_mode, InsertMode::File) {
+        dialog = dialog.add_filter("Supported files", FILE_MODE_ALLOWED_EXTENSIONS);
+    }
+    Ok(dialog.pick_file())
+}
+
+#[cfg(test)]
+fn pick_file_path_with_ops<FLeave, FPick, FEnter, FClear>(
+    mut leave: FLeave,
+    mut pick: FPick,
+    mut enter: FEnter,
+    mut clear: FClear,
+) -> Result<Option<PathBuf>, PickFilePathError>
+where
+    FLeave: FnMut() -> Result<(), String>,
+    FPick: FnMut() -> Result<Option<PathBuf>, String>,
+    FEnter: FnMut() -> Result<(), String>,
+    FClear: FnMut() -> Result<(), String>,
+{
+    leave().map_err(PickFilePathError::TerminalState)?;
+    match pick() {
+        Ok(selection) => {
+            enter().map_err(PickFilePathError::TerminalState)?;
+            clear().map_err(PickFilePathError::TerminalState)?;
+            Ok(selection)
+        }
+        Err(error) => {
+            match enter().map_err(PickFilePathError::TerminalState) {
+                Ok(()) => match clear().map_err(PickFilePathError::TerminalState) {
+                    Ok(()) => Err(PickFilePathError::Picker(error)),
+                    Err(restore_error) => Err(restore_error),
+                },
+                Err(restore_error) => Err(restore_error),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{cell::RefCell, rc::Rc};
+
+    #[test]
+    fn pick_file_path_sequence_restores_terminal_after_selection() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let shared = events.clone();
+        let result = pick_file_path_with_ops(
+            || {
+                shared.borrow_mut().push("leave");
+                Ok(())
+            },
+            || {
+                shared.borrow_mut().push("pick");
+                Ok(Some(PathBuf::from("/tmp/doc.md")))
+            },
+            || {
+                shared.borrow_mut().push("enter");
+                Ok(())
+            },
+            || {
+                shared.borrow_mut().push("clear");
+                Ok(())
+            },
+        )
+        .expect("picker should succeed");
+
+        assert_eq!(result, Some(PathBuf::from("/tmp/doc.md")));
+        assert_eq!(events.borrow().as_slice(), ["leave", "pick", "enter", "clear"]);
+    }
+
+    #[test]
+    fn pick_file_path_treats_enter_failure_as_fatal_restore_error() {
+        let error = pick_file_path_with_ops(
+            || Ok(()),
+            || Ok(None),
+            || Err("enter failed".to_string()),
+            || Ok(()),
+        )
+        .expect_err("enter failure should be fatal");
+
+        assert_eq!(
+            error,
+            PickFilePathError::TerminalState("enter failed".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_file_path_treats_clear_failure_as_fatal_restore_error() {
+        let error = pick_file_path_with_ops(
+            || Ok(()),
+            || Ok(None),
+            || Ok(()),
+            || Err("clear failed".to_string()),
+        )
+        .expect_err("clear failure should be fatal");
+
+        assert_eq!(
+            error,
+            PickFilePathError::TerminalState("clear failed".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_file_path_treats_leave_failure_as_fatal_terminal_error() {
+        let error = pick_file_path_with_ops(
+            || Err("leave failed".to_string()),
+            || Ok(None),
+            || Ok(()),
+            || Ok(()),
+        )
+        .expect_err("leave failure should be fatal");
+
+        assert_eq!(
+            error,
+            PickFilePathError::TerminalState("leave failed".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_file_path_returns_picker_error_only_after_successful_restore() {
+        let error = pick_file_path_with_ops(
+            || Ok(()),
+            || Err("dialog failed".to_string()),
+            || Ok(()),
+            || Ok(()),
+        )
+        .expect_err("picker failure should return picker error after restore");
+
+        assert_eq!(error, PickFilePathError::Picker("dialog failed".to_string()));
+    }
+
+    #[test]
+    fn pick_file_path_prioritizes_restore_failure_after_picker_error() {
+        let error = pick_file_path_with_ops(
+            || Ok(()),
+            || Err("dialog failed".to_string()),
+            || Err("enter failed".to_string()),
+            || Ok(()),
+        )
+        .expect_err("restore failure should be fatal");
+
+        assert_eq!(
+            error,
+            PickFilePathError::TerminalState("enter failed".to_string())
+        );
+    }
+
+    #[cfg(not(feature = "rfd-file-picker"))]
+    #[test]
+    fn host_builds_without_rfd_picker_feature() {
+        assert!(!cfg!(feature = "rfd-file-picker"));
+    }
 }

--- a/tui/crates/tui-kit-render/src/ui/app/overlays.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/overlays.rs
@@ -448,7 +448,8 @@ mod tests {
         let cfg = UiConfig::default().help;
 
         assert!(cfg.lines.iter().any(|line| {
-            line == "Insert form: ←/→ switch mode, Enter cycles mode / opens target picker / submits"
+            line
+                == "Insert form: ←/→ switch mode, Enter cycles mode / opens target picker / browses file / submits"
         }));
     }
 

--- a/tui/crates/tui-kit-render/src/ui/app/shared/status.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/shared/status.rs
@@ -309,7 +309,7 @@ mod tests {
     fn insert_tab_enter_hint_mentions_picker_and_submit() {
         assert_eq!(
             form_enter_hint(KINIC_INSERT_TAB_ID),
-            " cycle/picker/submit "
+            " cycle/picker/file/submit "
         );
     }
 
@@ -329,7 +329,7 @@ mod tests {
         let rendered = render_status_line(&ui);
 
         assert!(rendered.contains("Inserted 12 chunks"));
-        assert!(rendered.contains("cycle/picker/submit"));
+        assert!(rendered.contains("cycle/picker/file/submit"));
         assert!(rendered.contains("Tab/Shift+Tab"));
         assert!(rendered.contains("Esc"));
     }
@@ -385,7 +385,7 @@ mod tests {
             .focus(Focus::Form);
         let rendered = render_status_line(&ui);
 
-        assert!(rendered.contains("cycle/picker/submit"));
+        assert!(rendered.contains("cycle/picker/file/submit"));
         assert!(!rendered.contains("│  │"));
     }
 }

--- a/tui/crates/tui-kit-render/src/ui/app/types.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/types.rs
@@ -132,8 +132,9 @@ pub(crate) struct InsertFormCopy {
 pub(crate) fn insert_form_copy() -> InsertFormCopy {
     InsertFormCopy {
         mode_help: "File: .md/.markdown/.mdx/.txt/.json/.yaml/.yml/.csv/.log/.pdf\nInline Text: plain text\nManual Embedding: text + embedding JSON",
-        help_line: "Insert form: ←/→ switch mode, Enter cycles mode / opens target picker / submits",
-        status_enter_hint: " cycle/picker/submit ",
+        help_line:
+            "Insert form: ←/→ switch mode, Enter cycles mode / opens target picker / browses file / submits",
+        status_enter_hint: " cycle/picker/file/submit ",
     }
 }
 

--- a/tui/crates/tui-kit-runtime/src/lib.rs
+++ b/tui/crates/tui-kit-runtime/src/lib.rs
@@ -439,6 +439,7 @@ pub enum CoreAction {
     CreateSubmit,
     InsertInput(char),
     InsertBackspace,
+    InsertOpenFileDialog,
     InsertNextField,
     InsertPrevField,
     InsertCycleModePrev,
@@ -657,6 +658,11 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
                 InsertFormFocus::Embedding => {
                     state.insert_embedding.pop();
                 }
+            }
+        }
+        CoreAction::InsertOpenFileDialog => {
+            if insert_form_locked(state) {
+                return;
             }
         }
         CoreAction::InsertNextField => {

--- a/tui/crates/tui-kit-runtime/src/lib.rs
+++ b/tui/crates/tui-kit-runtime/src/lib.rs
@@ -6,9 +6,13 @@
 pub mod kinic_tabs;
 
 use candid::Nat;
+use std::path::PathBuf;
 use tui_kit_model::{UiContextNode, UiItemContent, UiItemSummary};
 
 pub const SETTINGS_ENTRY_DEFAULT_MEMORY_ID: &str = "default_memory";
+pub const FILE_MODE_ALLOWED_EXTENSIONS: &[&str] = &[
+    "md", "markdown", "mdx", "txt", "json", "yaml", "yml", "csv", "log", "pdf",
+];
 
 /// Core result type used by provider and reducer contracts.
 pub type CoreResult<T> = Result<T, CoreError>;
@@ -337,7 +341,8 @@ pub struct CoreState {
     pub insert_memory_placeholder: Option<String>,
     pub insert_tag: String,
     pub insert_text: String,
-    pub insert_file_path: String,
+    pub insert_file_path_input: String,
+    pub insert_selected_file_path: Option<PathBuf>,
     pub insert_embedding: String,
     pub insert_submit_state: CreateSubmitState,
     pub insert_spinner_frame: usize,
@@ -382,7 +387,8 @@ impl Default for CoreState {
             insert_memory_placeholder: None,
             insert_tag: String::new(),
             insert_text: String::new(),
-            insert_file_path: String::new(),
+            insert_file_path_input: String::new(),
+            insert_selected_file_path: None,
             insert_embedding: String::new(),
             insert_submit_state: CreateSubmitState::default(),
             insert_spinner_frame: 0,
@@ -632,7 +638,10 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
                 InsertFormFocus::Mode | InsertFormFocus::MemoryId | InsertFormFocus::Submit => {}
                 InsertFormFocus::Tag => state.insert_tag.push(*c),
                 InsertFormFocus::Text => state.insert_text.push(*c),
-                InsertFormFocus::FilePath => state.insert_file_path.push(*c),
+                InsertFormFocus::FilePath => {
+                    state.insert_selected_file_path = None;
+                    state.insert_file_path_input.push(*c);
+                }
                 InsertFormFocus::Embedding => state.insert_embedding.push(*c),
             }
             state.insert_error = None;
@@ -653,7 +662,8 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
                     state.insert_text.pop();
                 }
                 InsertFormFocus::FilePath => {
-                    state.insert_file_path.pop();
+                    state.insert_selected_file_path = None;
+                    state.insert_file_path_input.pop();
                 }
                 InsertFormFocus::Embedding => {
                     state.insert_embedding.pop();
@@ -1956,6 +1966,36 @@ mod tests {
         apply_core_action(&mut state, &CoreAction::InsertBackspace);
 
         assert_eq!(state.insert_memory_id, "aaaaa-aa");
+    }
+
+    #[test]
+    fn insert_file_path_backspace_edits_selected_path_buffer() {
+        let mut state = CoreState {
+            insert_focus: InsertFormFocus::FilePath,
+            insert_file_path_input: "/tmp/doc.pdf".to_string(),
+            insert_selected_file_path: Some(PathBuf::from("/tmp/doc.pdf")),
+            ..CoreState::default()
+        };
+
+        apply_core_action(&mut state, &CoreAction::InsertBackspace);
+
+        assert_eq!(state.insert_selected_file_path, None);
+        assert_eq!(state.insert_file_path_input, "/tmp/doc.pd");
+    }
+
+    #[test]
+    fn insert_file_path_input_appends_to_selected_path_buffer() {
+        let mut state = CoreState {
+            insert_focus: InsertFormFocus::FilePath,
+            insert_file_path_input: "/tmp/doc.pdf".to_string(),
+            insert_selected_file_path: Some(PathBuf::from("/tmp/doc.pdf")),
+            ..CoreState::default()
+        };
+
+        apply_core_action(&mut state, &CoreAction::InsertInput('x'));
+
+        assert_eq!(state.insert_selected_file_path, None);
+        assert_eq!(state.insert_file_path_input, "/tmp/doc.pdfx");
     }
 
     #[test]

--- a/tui/crates/tui-kit-runtime/src/lib.rs
+++ b/tui/crates/tui-kit-runtime/src/lib.rs
@@ -625,7 +625,7 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
     let previous_focus = state.focus;
     match action {
         CoreAction::InsertInput(c) => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             match state.insert_focus {
@@ -641,7 +641,7 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             }
         }
         CoreAction::InsertBackspace => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             match state.insert_focus {
@@ -661,24 +661,24 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             }
         }
         CoreAction::InsertOpenFileDialog => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
         }
         CoreAction::InsertNextField => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             state.insert_focus = next_insert_focus(state.insert_mode, state.insert_focus);
         }
         CoreAction::InsertPrevField => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             state.insert_focus = prev_insert_focus(state.insert_mode, state.insert_focus);
         }
         CoreAction::InsertCycleModePrev => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             state.insert_mode = prev_insert_mode(state.insert_mode);
@@ -689,7 +689,7 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             }
         }
         CoreAction::InsertCycleMode => {
-            if insert_form_locked(state) {
+            if is_insert_form_locked(state) {
                 return;
             }
             state.insert_mode = next_insert_mode(state.insert_mode);
@@ -1030,7 +1030,7 @@ fn prev_insert_mode(mode: InsertMode) -> InsertMode {
     }
 }
 
-fn insert_form_locked(state: &CoreState) -> bool {
+pub fn is_insert_form_locked(state: &CoreState) -> bool {
     state.insert_submit_state == CreateSubmitState::Submitting
 }
 
@@ -1924,6 +1924,24 @@ mod tests {
         apply_core_action(&mut state, &CoreAction::InsertInput('x'));
 
         assert_eq!(state.insert_text, "draft");
+    }
+
+    #[test]
+    fn is_insert_form_locked_only_while_submit_is_running() {
+        let idle = CoreState::default();
+        assert!(!is_insert_form_locked(&idle));
+
+        let submitting = CoreState {
+            insert_submit_state: CreateSubmitState::Submitting,
+            ..CoreState::default()
+        };
+        assert!(is_insert_form_locked(&submitting));
+
+        let error = CoreState {
+            insert_submit_state: CreateSubmitState::Error,
+            ..CoreState::default()
+        };
+        assert!(!is_insert_form_locked(&error));
     }
 
     #[test]

--- a/tui/examples/kinic/main.rs
+++ b/tui/examples/kinic/main.rs
@@ -1,7 +1,10 @@
 mod provider;
 
 use provider::KinicProvider;
-use tui_kit_host::runtime_loop::{run_provider_app, RuntimeLoopConfig};
+use tui_kit_host::{
+    runtime_loop::{RuntimeLoopConfig, run_provider_app},
+    terminal::rfd_file_picker,
+};
 use tui_kit_render::ui::{BrandingText, HeaderText, TabId, TabSpec, UiConfig};
 use tui_kit_runtime::PaneFocus;
 
@@ -20,6 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             initial_focus: PaneFocus::Items,
             ui_config: kinic_ui_config,
+            file_picker: Some(rfd_file_picker),
         },
     )
 }

--- a/tui/examples/mail/main.rs
+++ b/tui/examples/mail/main.rs
@@ -1,7 +1,10 @@
 mod provider;
 
 use provider::MailProvider;
-use tui_kit_host::runtime_loop::{run_provider_app, RuntimeLoopConfig};
+use tui_kit_host::{
+    runtime_loop::{RuntimeLoopConfig, run_provider_app},
+    terminal::rfd_file_picker,
+};
 use tui_kit_render::ui::{BrandingText, HeaderText, TabId, TabSpec, UiConfig};
 use tui_kit_runtime::PaneFocus;
 
@@ -19,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             tab_ids: &["mail-inbox", "mail-invoices", "mail-alerts", "mail-news"],
             initial_focus: PaneFocus::Items,
             ui_config: mail_ui_config,
+            file_picker: Some(rfd_file_picker),
         },
     )
 }

--- a/tui/examples/task/main.rs
+++ b/tui/examples/task/main.rs
@@ -1,7 +1,10 @@
 mod provider;
 
 use provider::TaskProvider;
-use tui_kit_host::runtime_loop::{run_provider_app, RuntimeLoopConfig};
+use tui_kit_host::{
+    runtime_loop::{RuntimeLoopConfig, run_provider_app},
+    terminal::rfd_file_picker,
+};
 use tui_kit_render::ui::{BrandingText, HeaderText, TabId, TabSpec, UiConfig};
 use tui_kit_runtime::PaneFocus;
 
@@ -24,6 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             initial_focus: PaneFocus::Items,
             ui_config: task_ui_config,
+            file_picker: Some(rfd_file_picker),
         },
     )
 }

--- a/tui/src/provider.rs
+++ b/tui/src/provider.rs
@@ -1557,6 +1557,7 @@ impl DataProvider for KinicProvider {
                     effects.push(effect);
                 }
             }
+            CoreAction::InsertOpenFileDialog => {}
             CoreAction::RefreshCurrentView => {
                 effects.extend(self.refresh_current_view());
             }

--- a/tui/src/provider.rs
+++ b/tui/src/provider.rs
@@ -13,9 +13,10 @@ use crate::{
 use serde::Deserialize;
 use tokio::runtime::Runtime;
 use tui_kit_runtime::{
-    CoreAction, CoreEffect, CoreResult, CoreState, CreateCostState, DataProvider, InsertMode,
-    LoadedCreateCost, MemorySelectorContext, MemorySelectorItem, PaneFocus, ProviderOutput,
-    ProviderSnapshot, SessionAccountOverview, SessionSettingsSnapshot,
+    CoreAction, CoreEffect, CoreResult, CoreState, CreateCostState, DataProvider,
+    FILE_MODE_ALLOWED_EXTENSIONS, InsertMode, LoadedCreateCost, MemorySelectorContext,
+    MemorySelectorItem, PaneFocus, ProviderOutput, ProviderSnapshot, SessionAccountOverview,
+    SessionSettingsSnapshot,
     kinic_tabs::{
         KINIC_CREATE_TAB_ID, KINIC_INSERT_TAB_ID, KINIC_MARKET_TAB_ID, KINIC_MEMORIES_TAB_ID,
         KINIC_SETTINGS_TAB_ID,
@@ -762,9 +763,7 @@ impl KinicProvider {
     fn build_insert_request(&self, state: &CoreState) -> InsertRequest {
         let memory_id = state.insert_memory_id.trim().to_string();
         let tag = state.insert_tag.trim().to_string();
-        let normalized_file_path = normalize_insert_file_path_input(state.insert_file_path.trim());
-        let file_path = (!normalized_file_path.is_empty())
-            .then(|| std::path::PathBuf::from(normalized_file_path));
+        let file_path = resolved_insert_file_path(state);
 
         match state.insert_mode {
             InsertMode::File => match file_path {
@@ -861,9 +860,9 @@ impl KinicProvider {
     fn validate_insert_state(&self, state: &CoreState) -> Result<(), String> {
         match state.insert_mode {
             InsertMode::File => {
-                validate_supported_file_mode_path(normalize_insert_file_path_input(
-                    state.insert_file_path.trim(),
-                ))?;
+                let file_path = resolved_insert_file_path(state)
+                    .ok_or_else(|| "File path is required for file insert.".to_string())?;
+                validate_supported_file_mode_path(file_path.as_path())?;
             }
             InsertMode::InlineText => {
                 if state.insert_text.trim().is_empty() {
@@ -1357,16 +1356,15 @@ impl KinicProvider {
     }
 }
 
-fn validate_existing_insert_file_path(path: &str, mode_label: &str) -> Result<(), String> {
-    if path.is_empty() {
+fn validate_existing_insert_file_path(path: &Path, mode_label: &str) -> Result<(), String> {
+    if path.as_os_str().is_empty() {
         return Err(format!("File path is required for {mode_label} insert."));
     }
 
-    let file_path = Path::new(path);
-    if !file_path.exists() {
+    if !path.exists() {
         return Err(format!("File path does not exist for {mode_label} insert."));
     }
-    if !file_path.is_file() {
+    if !path.is_file() {
         return Err(format!(
             "File path must point to a file for {mode_label} insert."
         ));
@@ -1392,15 +1390,10 @@ fn normalize_insert_file_path_input(path: &str) -> &str {
     trimmed
 }
 
-const FILE_MODE_ALLOWED_EXTENSIONS: &[&str] = &[
-    "md", "markdown", "mdx", "txt", "json", "yaml", "yml", "csv", "log", "pdf",
-];
-
-fn validate_supported_file_mode_path(path: &str) -> Result<(), String> {
+fn validate_supported_file_mode_path(path: &Path) -> Result<(), String> {
     validate_existing_insert_file_path(path, "file")?;
-    let file_path = Path::new(path);
 
-    let Some(extension) = file_path
+    let Some(extension) = path
         .extension()
         .and_then(|extension| extension.to_str())
     else {
@@ -1435,6 +1428,13 @@ fn insert_file_path_is_pdf(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("pdf"))
+}
+
+fn resolved_insert_file_path(state: &CoreState) -> Option<std::path::PathBuf> {
+    state.insert_selected_file_path.clone().or_else(|| {
+        let normalized = normalize_insert_file_path_input(state.insert_file_path_input.trim());
+        (!normalized.is_empty()).then(|| std::path::PathBuf::from(normalized))
+    })
 }
 
 impl DataProvider for KinicProvider {

--- a/tui/src/provider/tests.rs
+++ b/tui/src/provider/tests.rs
@@ -3,6 +3,7 @@ use crate::create_domain::derive_create_cost;
 use candid::Nat;
 use std::{
     env, fs,
+    path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tui_kit_runtime::{
@@ -382,7 +383,7 @@ fn validate_insert_state_rejects_missing_file() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: env::temp_dir()
+        insert_file_path_input: env::temp_dir()
             .join("kinic-missing-file.md")
             .display()
             .to_string(),
@@ -403,7 +404,7 @@ fn validate_insert_state_accepts_existing_non_pdf_file() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: file_path.clone(),
+        insert_file_path_input: file_path.clone(),
         ..CoreState::default()
     };
 
@@ -419,7 +420,7 @@ fn validate_insert_state_accepts_uppercase_pdf_extension() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: file_path.clone(),
+        insert_file_path_input: file_path.clone(),
         ..CoreState::default()
     };
 
@@ -435,7 +436,7 @@ fn validate_insert_state_rejects_unsupported_file_extension() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: file_path.clone(),
+        insert_file_path_input: file_path.clone(),
         ..CoreState::default()
     };
 
@@ -561,7 +562,7 @@ fn mock_insert_rejects_missing_pdf_path() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: String::new(),
+        insert_file_path_input: String::new(),
         ..CoreState::default()
     };
 
@@ -584,7 +585,7 @@ fn mock_insert_accepts_existing_pdf_without_prevalidating_conversion() {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: file_path.clone(),
+        insert_file_path_input: file_path.clone(),
         ..CoreState::default()
     };
 
@@ -610,7 +611,7 @@ fn mock_insert_accepts_file_without_inline_text() {
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
         insert_text: "   ".to_string(),
-        insert_file_path: file_path.clone(),
+        insert_file_path_input: file_path.clone(),
         ..CoreState::default()
     };
 
@@ -659,7 +660,7 @@ fn build_insert_request_uses_inline_text_mode_without_file_path() {
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
         insert_text: "hello".to_string(),
-        insert_file_path: "/tmp/ignored.md".to_string(),
+        insert_file_path_input: "/tmp/ignored.md".to_string(),
         ..CoreState::default()
     };
 
@@ -725,7 +726,7 @@ fn build_insert_request_uses_file_mode_for_non_pdf_paths() {
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
         insert_text: "ignored".to_string(),
-        insert_file_path: "/tmp/doc.md".to_string(),
+        insert_file_path_input: "/tmp/doc.md".to_string(),
         ..CoreState::default()
     };
 
@@ -741,13 +742,35 @@ fn build_insert_request_uses_file_mode_for_non_pdf_paths() {
 }
 
 #[test]
+fn build_insert_request_prefers_selected_file_path_over_manual_input() {
+    let provider = KinicProvider::new(mock_config());
+    let state = CoreState {
+        insert_mode: InsertMode::File,
+        insert_memory_id: "aaaaa-aa".to_string(),
+        insert_tag: "docs".to_string(),
+        insert_file_path_input: "/tmp/manual.md".to_string(),
+        insert_selected_file_path: Some(PathBuf::from("/tmp/dialog.pdf")),
+        ..CoreState::default()
+    };
+
+    assert_eq!(
+        provider.build_insert_request(&state),
+        InsertRequest::Pdf {
+            memory_id: "aaaaa-aa".to_string(),
+            tag: "docs".to_string(),
+            file_path: PathBuf::from("/tmp/dialog.pdf"),
+        }
+    );
+}
+
+#[test]
 fn build_insert_request_uses_file_mode_for_pdf_paths() {
     let provider = KinicProvider::new(mock_config());
     let state = CoreState {
         insert_mode: InsertMode::File,
         insert_memory_id: "aaaaa-aa".to_string(),
         insert_tag: "docs".to_string(),
-        insert_file_path: "/tmp/doc.PDF".to_string(),
+        insert_file_path_input: "/tmp/doc.PDF".to_string(),
         ..CoreState::default()
     };
 
@@ -757,6 +780,44 @@ fn build_insert_request_uses_file_mode_for_pdf_paths() {
             memory_id: "aaaaa-aa".to_string(),
             tag: "docs".to_string(),
             file_path: std::path::PathBuf::from("/tmp/doc.PDF"),
+        }
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn build_insert_request_preserves_non_utf8_selected_file_path() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let provider = KinicProvider::new(mock_config());
+    let selected_path = PathBuf::from(OsString::from_vec(vec![
+        b'/',
+        b't',
+        b'm',
+        b'p',
+        b'/',
+        0xf0,
+        0x80,
+        b'.',
+        b'm',
+        b'd',
+    ]));
+    let state = CoreState {
+        insert_mode: InsertMode::File,
+        insert_memory_id: "aaaaa-aa".to_string(),
+        insert_tag: "docs".to_string(),
+        insert_selected_file_path: Some(selected_path.clone()),
+        ..CoreState::default()
+    };
+
+    assert_eq!(
+        provider.build_insert_request(&state),
+        InsertRequest::Normal {
+            memory_id: "aaaaa-aa".to_string(),
+            tag: "docs".to_string(),
+            text: None,
+            file_path: Some(selected_path),
         }
     );
 }


### PR DESCRIPTION
## Summary
- split and expand the reusable TUI kit host/runtime/render layers across the workspace
- redesign Kinic insert modes and related validation/command flows
- add OS file picker support for insert file paths in the TUI
- deduplicate insert form lock checks by centralizing the lock condition in runtime
- refresh supporting CLI/docs/scripts and update lockfiles for the new dependencies

## Testing
- `cargo test -p tui-kit-runtime --quiet`
- `cargo test -p tui-kit-host --quiet`
- `cargo test -p kinic-tui --quiet`