### PR TITLE
Fix chat input cursor reset while preserving in-progress spacing

### DIFF
--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -9,8 +9,8 @@ use tui_kit_render::ui::{AnimationState, Focus, TabId, TuiKitUi, UiConfig};
 use tui_kit_runtime::{
     CoreAction, CoreEffect, CoreState, DataProvider, PaneFocus, PickerState, apply_snapshot,
     chat_commands::{
-        UNKNOWN_SLASH_COMMAND_MESSAGE, chat_slash_command_action, matching_slash_commands,
-        normalize_chat_input_lines, selected_slash_command_action,
+        UNKNOWN_SLASH_COMMAND_MESSAGE, chat_slash_command_action, flatten_chat_input_for_display,
+        matching_slash_commands, normalize_chat_input_lines, selected_slash_command_action,
     },
     dispatch_action, is_insert_form_locked,
     kinic_tabs::{
@@ -1009,7 +1009,7 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
 }
 
 fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
-    normalize_chat_input_lines(textarea.lines().join("\n").as_str())
+    flatten_chat_input_for_display(textarea.lines().join("\n").as_str())
 }
 
 fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
@@ -1027,7 +1027,7 @@ fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
         .map(|line| line.chars().take(cursor_col).collect::<String>())
         .unwrap_or_default();
     prefix_lines.push(current_prefix);
-    normalize_chat_input_lines(prefix_lines.join("\n").as_str())
+    flatten_chat_input_for_display(prefix_lines.join("\n").as_str())
         .chars()
         .count()
 }
@@ -1072,10 +1072,9 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let normalized_chat_input =
-        normalize_chat_input_lines(textareas.chat_input.lines().join("\n").as_str());
-    if state.chat_input != normalized_chat_input {
-        state.chat_input = normalized_chat_input;
+    let display_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+    if state.chat_input != display_chat_input {
+        state.chat_input = display_chat_input;
     }
 }
 

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -1,7 +1,7 @@
 #[path = "form_tab_flow.rs"]
 mod form_tab_flow;
 
-use ratatui_textarea::{Input as TextAreaInput, Key as TextAreaKey, TextArea};
+use ratatui_textarea::{CursorMove, Input as TextAreaInput, Key as TextAreaKey, TextArea};
 use std::{io, time::Duration};
 use tui_kit_render::theme::Theme;
 use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
@@ -159,6 +159,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             terminal.draw(|frame| {
                 let focus = ui_focus_from_pane(state.focus);
                 let insert_file_path_display = insert_file_path_display(&state);
+                let visible_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
                 let ui = TuiKitUi::new(&theme)
                     .ui_config(ui_config())
                     .ui_summaries(&state.list_items)
@@ -223,10 +224,9 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                     .filtered_context_indices(&[])
                     .candidates(&[])
                     .chat_messages(&state.chat_messages)
-                    .chat_input(&state.chat_input)
-                    .chat_input_cursor(textarea_cursor(
+                    .chat_input(visible_chat_input.as_str())
+                    .chat_input_cursor(chat_input_cursor(
                         active_textarea(&state),
-                        ActiveTextarea::ChatInput,
                         &textareas.chat_input,
                     ))
                     .chat_command_selected(chat_command_selection(&state, &textareas))
@@ -634,9 +634,8 @@ fn build_ui<'a>(
         .candidates(&[])
         .chat_messages(&state.chat_messages)
         .chat_input(&state.chat_input)
-        .chat_input_cursor(textarea_cursor(
+        .chat_input_cursor(chat_input_cursor(
             active_textarea(state),
-            ActiveTextarea::ChatInput,
             &textareas.chat_input,
         ))
         .chat_command_selected(chat_command_selection(state, textareas))
@@ -995,10 +994,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_textarea_from_string(
-        &mut textareas.chat_input,
-        normalize_chat_input_lines(state.chat_input.as_str()).as_str(),
-    );
+    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str());
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1010,6 +1006,51 @@ fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
 
 fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
+}
+
+fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
+    normalize_chat_input_lines(textarea.lines().join("\n").as_str())
+}
+
+fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
+    let lines = textarea.lines();
+    let last_row = lines.len().saturating_sub(1);
+    let (cursor_row, cursor_col) = textarea.cursor();
+    let effective_row = cursor_row.min(last_row);
+    let mut prefix_lines = lines
+        .iter()
+        .take(effective_row)
+        .map(|line| line.as_str().to_string())
+        .collect::<Vec<_>>();
+    let current_prefix = lines
+        .get(effective_row)
+        .map(|line| line.chars().take(cursor_col).collect::<String>())
+        .unwrap_or_default();
+    prefix_lines.push(current_prefix);
+    normalize_chat_input_lines(prefix_lines.join("\n").as_str())
+        .chars()
+        .count()
+}
+
+fn chat_input_cursor(
+    active: Option<ActiveTextarea>,
+    textarea: &TextArea<'static>,
+) -> Option<(usize, usize)> {
+    if active != Some(ActiveTextarea::ChatInput) {
+        return None;
+    }
+    Some((0, normalized_chat_cursor_col(textarea)))
+}
+
+fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str) {
+    // Chat input remains a single-line UI, but the widget may still hold raw pasted
+    // newlines or trailing spaces while editing. Only rebuild when the normalized
+    // text actually diverges so equivalent edits keep the cursor stable.
+    if normalized_chat_textarea_value(textarea) == value {
+        return;
+    }
+    sync_textarea_from_string(textarea, value);
+    textarea.move_cursor(CursorMove::End);
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -514,17 +514,77 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 }
 
 #[test]
-fn chat_textarea_multiline_paste_is_normalized_to_single_line() {
-    let mut state = CoreState {
-        chat_input: "first line\nsecond line".to_string(),
-        ..CoreState::default()
-    };
+fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
+    let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("first line\nsecond line");
 
-    sync_form_textareas_from_state(&mut textareas, &state);
     sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
 
     assert_eq!(state.chat_input, "first line second line");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line\nsecond line"
+    );
+}
+
+#[test]
+fn chat_textarea_sync_state_normalizes_trailing_space() {
+    let mut state = CoreState::default();
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+
+    sync_state_from_textareas(&mut state, &textareas);
+
+    assert_eq!(state.chat_input, "hello");
+}
+
+#[test]
+fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget() {
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+    let state = CoreState {
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+}
+
+#[test]
+fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input.input(textarea_input_from_key_event(
+        crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Left,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    ));
+    let cursor_before = textareas.chat_input.cursor();
+    let state = CoreState {
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+    assert_eq!(textareas.chat_input.cursor(), cursor_before);
+}
+
+#[test]
+fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
+    let mut textarea = textarea_from_text("first line\nsecond line");
+    textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
+
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 17))
+    );
 }
 
 #[test]
@@ -723,6 +783,33 @@ fn chat_submit_slash_all_switches_scope_without_sending_message() {
 }
 
 #[test]
+fn chat_submit_normalizes_multiline_input_before_sending_message() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+    sync_state_from_textareas(&mut state, &textareas);
+
+    let handled =
+        handle_chat_submit_or_command(&mut provider, &mut state, &mut hooks, &mut textareas)
+            .expect("chat submit");
+
+    assert!(handled);
+    assert_eq!(
+        state.chat_messages,
+        vec![("user".to_string(), "first line second line".to_string())]
+    );
+    assert!(state.chat_input.is_empty());
+}
+
+#[test]
 fn chat_submit_slash_all_is_idempotent_when_already_on_all_scope() {
     let mut provider = TestProvider::ok();
     let mut hooks = NoopRuntimeHooks;
@@ -731,6 +818,29 @@ fn chat_submit_slash_all_is_idempotent_when_already_on_all_scope() {
         focus: PaneFocus::Extra,
         chat_input: "/all".to_string(),
         chat_scope: tui_kit_runtime::ChatScope::All,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+
+    let handled =
+        handle_chat_submit_or_command(&mut provider, &mut state, &mut hooks, &mut textareas)
+            .expect("slash command");
+
+    assert!(handled);
+    assert_eq!(state.chat_scope, tui_kit_runtime::ChatScope::All);
+    assert!(state.chat_messages.is_empty());
+    assert!(state.chat_input.is_empty());
+}
+
+#[test]
+fn chat_submit_slash_all_trims_trailing_space_before_matching_command() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "/all ".to_string(),
+        chat_scope: tui_kit_runtime::ChatScope::Selected,
         ..CoreState::default()
     };
     let mut textareas = FormTextareas::default();

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -530,14 +530,27 @@ fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
 }
 
 #[test]
-fn chat_textarea_sync_state_normalizes_trailing_space() {
+fn chat_textarea_sync_state_preserves_trailing_space() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("hello ");
 
     sync_state_from_textareas(&mut state, &textareas);
 
-    assert_eq!(state.chat_input, "hello");
+    assert_eq!(state.chat_input, "hello ");
+}
+
+#[test]
+fn chat_textarea_display_value_preserves_trailing_space() {
+    let textareas = FormTextareas {
+        chat_input: textarea_from_text("hello "),
+        ..FormTextareas::default()
+    };
+
+    assert_eq!(
+        normalized_chat_textarea_value(&textareas.chat_input),
+        "hello "
+    );
 }
 
 #[test]
@@ -545,7 +558,7 @@ fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget()
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("hello ");
     let state = CoreState {
-        chat_input: "hello".to_string(),
+        chat_input: "hello ".to_string(),
         ..CoreState::default()
     };
 
@@ -566,7 +579,7 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
     ));
     let cursor_before = textareas.chat_input.cursor();
     let state = CoreState {
-        chat_input: "hello".to_string(),
+        chat_input: "hello ".to_string(),
         ..CoreState::default()
     };
 
@@ -574,6 +587,17 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
 
     assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
     assert_eq!(textareas.chat_input.cursor(), cursor_before);
+}
+
+#[test]
+fn chat_input_cursor_keeps_trailing_space_visible() {
+    let mut textarea = textarea_from_text("hello ");
+    textarea.move_cursor(ratatui_textarea::CursorMove::End);
+
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 6))
+    );
 }
 
 #[test]
@@ -585,6 +609,79 @@ fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
         Some((0, 17))
     );
+}
+
+#[test]
+fn chat_textarea_display_value_keeps_space_before_next_char() {
+    let textareas = FormTextareas {
+        chat_input: textarea_from_text("hello w"),
+        ..FormTextareas::default()
+    };
+
+    assert_eq!(
+        normalized_chat_textarea_value(&textareas.chat_input),
+        "hello w"
+    );
+}
+
+#[test]
+fn chat_textarea_space_input_updates_state_and_widget_cursor() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat textarea input");
+
+    assert!(handled);
+    assert_eq!(state.chat_input, "hello ");
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+    assert_eq!(textareas.chat_input.cursor(), (0, 6));
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textareas.chat_input),
+        Some((0, 6))
+    );
+}
+
+#[test]
+fn build_ui_places_chat_cursor_after_trailing_space() {
+    let theme = Theme::default();
+    let cfg = test_runtime_config();
+    let animation = AnimationState::new();
+    let state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "hello ".to_string(),
+        chat_open: true,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let ui = build_ui(
+        &theme, &cfg, &state, &textareas, 0, 0, false, false, &animation,
+    );
+    let cursor = ui.cursor_position_for_area(Rect::new(0, 0, 120, 40));
+
+    assert!(cursor.is_some());
+    let (x, _) = cursor.expect("chat cursor");
+    assert!(x > 0);
 }
 
 #[test]

--- a/tui/crates/tui-kit-render/src/ui/app/screens/memories/chat_panel.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/screens/memories/chat_panel.rs
@@ -14,7 +14,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::ui::app::{Focus, TuiKitUi};
 use crate::ui::theme::Theme;
-use tui_kit_runtime::chat_commands::{matching_slash_commands, normalize_chat_input_lines};
+use tui_kit_runtime::chat_commands::{flatten_chat_input_for_display, matching_slash_commands};
 
 pub(super) const CHAT_INPUT_MAX_HEIGHT: u16 = 1;
 
@@ -460,7 +460,7 @@ pub(super) fn visible_chat_input_rows(
     cursor_col: usize,
     max_width: u16,
 ) -> VisibleChatInputRows {
-    let single_line_value = normalize_chat_input_lines(value);
+    let single_line_value = flatten_chat_input_for_display(value);
     let mut source_rows = if single_line_value.is_empty() {
         vec![placeholder.to_string()]
     } else {

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -13,17 +13,18 @@ pub const UNKNOWN_SLASH_COMMAND_MESSAGE: &str = "Unknown chat command. Try /new 
 
 /// Commands whose prefix matches `input` (trimmed), for autocomplete UI.
 pub fn matching_slash_commands(input: &str) -> Vec<&'static str> {
-    let trimmed = input.trim();
-    if !trimmed.starts_with('/') {
+    let trimmed_end = input.trim_end();
+    let command_input = trimmed_end.trim_start();
+    if !command_input.starts_with('/') {
         return Vec::new();
     }
-    if trimmed == "/" {
+    if command_input == "/" {
         return CHAT_SLASH_COMMANDS.to_vec();
     }
     CHAT_SLASH_COMMANDS
         .iter()
         .copied()
-        .filter(|command| command.starts_with(trimmed))
+        .filter(|command| command.starts_with(command_input))
         .collect()
 }
 
@@ -43,6 +44,12 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
         .and_then(chat_slash_command_action)
 }
 
+/// Collapse multiline chat input to one line for in-progress display.
+/// This preserves user-typed spacing and only replaces line breaks with spaces.
+pub fn flatten_chat_input_for_display(value: &str) -> String {
+    value.split('\n').collect::<Vec<_>>().join(" ")
+}
+
 /// Collapse multiline chat input to one line (trimmed lines joined with spaces).
 pub fn normalize_chat_input_lines(value: &str) -> String {
     value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
@@ -55,8 +62,14 @@ mod tests {
     #[test]
     fn matching_slash_commands_filters_by_prefix() {
         assert_eq!(matching_slash_commands("/"), vec!["/new", "/all"]);
+        assert_eq!(matching_slash_commands("/all "), vec!["/all"]);
         assert!(matching_slash_commands("/s").is_empty());
         assert!(matching_slash_commands("hello").is_empty());
+    }
+
+    #[test]
+    fn flatten_chat_input_for_display_preserves_spacing() {
+        assert_eq!(flatten_chat_input_for_display("a \n  b"), "a    b");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve trailing spaces
- separate display flattening from submit-time normalization so the UI stays single-line without resetting the cursor
- keep slash command suggestions working with trailing spaces and add regression coverage for cursor, spacing, and submit behavior