### PR TITLE
Add CLI memory and prefs commands with JSON read output

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,16 @@ km.add_user("<memory canister id>", "w7x7r-cok77-7x4qo-hqaaa-aaaaa-b", "writer")
 CLI example:
 ```bash
 # Give everyone reader access
-cargo run -- --identity <name> config \
+cargo run -- --identity <name> config users add \
   --memory-id <memory canister id> \
-  --add-user anonymous reader
+  --principal anonymous \
+  --role reader
 
 # Grant writer access to a specific principal
-cargo run -- --identity <name> config \
+cargo run -- --identity <name> config users add \
   --memory-id <memory canister id> \
-  --add-user w7x7r-cok77-7x4qo-hqaaa-aaaaa-b writer
+  --principal w7x7r-cok77-7x4qo-hqaaa-aaaaa-b \
+  --role writer
 ```
 
 Notes:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -227,7 +227,8 @@ Notes:
 ### Manage local preferences shared with the TUI
 
 These commands read and write the same local settings file used by the TUI at `~/.config/kinic/tui.yaml`.
-They do not require `--identity` because they only update local preferences.
+They do not require `--identity` when they only update local preferences.
+`prefs add-memory --validate` is the exception and requires `--identity` or `--ii` because it verifies access against the target memory canister before saving.
 `prefs show` returns JSON so it can be consumed reliably by AI agents, shell scripts, and other tools.
 All `prefs` commands now return JSON so agents can consume both reads and mutations with one stable contract.
 
@@ -243,7 +244,10 @@ Example output:
 {
   "default_memory_id": null,
   "saved_tags": [],
-  "manual_memory_ids": []
+  "manual_memory_ids": [],
+  "chat_overall_top_k": 8,
+  "chat_per_memory_cap": 3,
+  "chat_mmr_lambda": 70
 }
 ```
 
@@ -276,7 +280,16 @@ Manage manually tracked memories:
 
 ```bash
 cargo run -- prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+cargo run -- --identity alice prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai --validate
 cargo run -- prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+```
+
+Manage chat retrieval tuning used by `all memories` chat:
+
+```bash
+cargo run -- prefs set-chat-overall-top-k --value 10
+cargo run -- prefs set-chat-per-memory-cap --value 4
+cargo run -- prefs set-chat-mmr-lambda --value 80
 ```
 
 ### Update a memory canister instance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,51 @@ Command-line companion for deploying and operating Kinic “memory” canisters.
 
 Use either `--identity` (dfx identity name stored in the system keychain) or `--ii` (Internet Identity login). Use `--ic` to talk to mainnet; omit it (or leave false) for the local replica. If you are not using `--ii`, `--identity <name>` is required for CLI commands.
 
+Agent-friendly discovery tips:
+- Start with `kinic-cli --help` for auth mode guidance and top-level entrypoints
+- Start with `kinic-cli capabilities` to get a JSON description of commands, auth requirements, output modes, major arguments, and arg-group constraints
+- Use `kinic-cli prefs --help` to inspect the JSON contract for shared local preferences
+- `capabilities` and `prefs` commands return JSON; existing network commands currently keep text output
+
+### Capabilities JSON
+
+Use this command when an agent needs a machine-readable description of the CLI before choosing a command:
+
+```bash
+cargo run -- capabilities
+```
+
+Example output:
+
+```json
+{
+  "cli": "kinic-cli",
+  "version": "0.1.2",
+  "auth_summary": "Network commands require --identity or --ii unless noted otherwise. The TUI requires --identity.",
+  "commands": [
+    {
+      "name": "prefs",
+      "summary": "Manage local Kinic preferences shared with the TUI.",
+      "requires_auth": false,
+      "auth_modes": [],
+      "output_mode": "json",
+      "interactive": false,
+      "arguments": [],
+      "subcommands": [
+        {
+          "name": "show",
+          "summary": "Show local preferences shared with the TUI.",
+          "output_mode": "json",
+          "arguments": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+For commands with compound input rules, `capabilities` also includes `arg_groups`. For example, `insert` exposes the required `insert_input` group so an agent can see that one of `text` or `file_path` must be provided. Arguments may also include `relations` with `requires` and `conflicts` when those constraints are available.
+
 ```bash
 cargo run -- --identity alice list
 cargo run -- --identity alice create \
@@ -138,6 +183,61 @@ cargo run -- --identity alice config \
 Notes:
 - `anonymous` assigns the role to everyone; admin cannot be granted to `anonymous`.
 - Principals are validated; invalid text fails fast.
+
+### Manage local preferences shared with the TUI
+
+These commands read and write the same local settings file used by the TUI at `~/.config/kinic/tui.yaml`.
+They do not require `--identity` because they only update local preferences.
+`prefs show` returns JSON so it can be consumed reliably by AI agents, shell scripts, and other tools.
+All `prefs` commands now return JSON so agents can consume both reads and mutations with one stable contract.
+
+Show the current shared preferences:
+
+```bash
+cargo run -- prefs show
+```
+
+Example output:
+
+```json
+{
+  "default_memory_id": null,
+  "saved_tags": [],
+  "manual_memory_ids": []
+}
+```
+
+Set or clear the default memory:
+
+```bash
+cargo run -- prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+cargo run -- prefs clear-default-memory
+```
+
+Example mutation output:
+
+```json
+{
+  "resource": "default_memory_id",
+  "action": "set",
+  "status": "updated",
+  "value": "yta6k-5x777-77774-aaaaa-cai"
+}
+```
+
+Manage saved tags:
+
+```bash
+cargo run -- prefs add-tag --tag quarterly_report
+cargo run -- prefs remove-tag --tag quarterly_report
+```
+
+Manage manually tracked memories:
+
+```bash
+cargo run -- prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+cargo run -- prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+```
 
 ### Update a memory canister instance
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,11 +50,14 @@ Command-line companion for deploying and operating Kinic “memory” canisters.
 
 Use either `--identity` (dfx identity name stored in the system keychain) or `--ii` (Internet Identity login). Use `--ic` to talk to mainnet; omit it (or leave false) for the local replica. If you are not using `--ii`, `--identity <name>` is required for CLI commands.
 
+Machine-consumption entrypoint:
+- Agent/public skill: [`skills/kinic-cli-user/SKILL.md`](../skills/kinic-cli-user/SKILL.md)
+
 Agent-friendly discovery tips:
 - Start with `kinic-cli --help` for auth mode guidance and top-level entrypoints
 - Start with `kinic-cli capabilities` to get a JSON description of commands, auth requirements, output modes, major arguments, and arg-group constraints
 - Use `kinic-cli prefs --help` to inspect the JSON contract for shared local preferences
-- `capabilities` and `prefs` commands return JSON; existing network commands currently keep text output
+- `capabilities` and `prefs` commands return JSON; `list`, `show`, and `search` also support `--json` for agent/script consumption while keeping human-friendly text output by default
 
 ### Capabilities JSON
 
@@ -170,6 +173,15 @@ cargo run -- --identity alice search \
 
 The CLI fetches an embedding for the query and prints the scored matches returned by the memory canister.
 
+For AI agents or scripts, use JSON output:
+
+```bash
+cargo run -- --identity alice search \
+  --memory-id yta6k-5x777-77774-aaaaa-cai \
+  --query "Hello" \
+  --json
+```
+
 Search across all searchable memories:
 
 ```bash
@@ -179,15 +191,37 @@ cargo run -- --identity alice search \
 ```
 
 When `--all` is used, results are merged and printed with the source memory id.
+With `--json`, the output also includes `searched_memory_ids` and `failed_memory_ids` when some memory searches fail.
 
 ### Show memory details
 
 ```bash
 cargo run -- --identity alice show \
   --memory-id yta6k-5x777-77774-aaaaa-cai
+
+cargo run -- --identity alice show \
+  --memory-id yta6k-5x777-77774-aaaaa-cai \
+  --json
 ```
 
-The command prints the memory name, version, dimension, owners, stable memory size, cycle amount, and users.
+The command prints the memory name, optional description, version, dimension, owners, stable memory size, cycle amount, and users.
+
+### List memories for agents
+
+```bash
+cargo run -- --identity alice list --json
+```
+
+`list --json` returns a structured `items[]` payload with `memory_id` and launcher `status`.
+
+### Agent workflow
+
+For agent-driven usage, prefer:
+
+1. `list --json` to discover candidate memories
+2. `show --json` to fetch metadata and access context
+3. `search --json` to fetch retrieval evidence
+4. summarize in the agent, rather than relying on `ask-ai`
 
 ### Rename a memory
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -170,14 +170,54 @@ cargo run -- --identity alice search \
 
 The CLI fetches an embedding for the query and prints the scored matches returned by the memory canister.
 
-### Manage config (add user)
-
-Grant a role for a user on a memory canister:
+Search across all searchable memories:
 
 ```bash
-cargo run -- --identity alice config \
+cargo run -- --identity alice search \
+  --all \
+  --query "Hello"
+```
+
+When `--all` is used, results are merged and printed with the source memory id.
+
+### Show memory details
+
+```bash
+cargo run -- --identity alice show \
+  --memory-id yta6k-5x777-77774-aaaaa-cai
+```
+
+The command prints the memory name, version, dimension, owners, stable memory size, cycle amount, and users.
+
+### Rename a memory
+
+```bash
+cargo run -- --identity alice rename \
   --memory-id yta6k-5x777-77774-aaaaa-cai \
-  --add-user <principal|anonymous> <admin|writer|reader>
+  --name "Renamed demo memory"
+```
+
+### Manage config (add user)
+
+Manage users for a memory canister:
+
+```bash
+cargo run -- --identity alice config users list \
+  --memory-id yta6k-5x777-77774-aaaaa-cai
+
+cargo run -- --identity alice config users add \
+  --memory-id yta6k-5x777-77774-aaaaa-cai \
+  --principal <principal|anonymous> \
+  --role <admin|writer|reader>
+
+cargo run -- --identity alice config users change \
+  --memory-id yta6k-5x777-77774-aaaaa-cai \
+  --principal <principal|anonymous> \
+  --role <admin|writer|reader>
+
+cargo run -- --identity alice config users remove \
+  --memory-id yta6k-5x777-77774-aaaaa-cai \
+  --principal <principal|anonymous>
 ```
 
 Notes:
@@ -255,6 +295,22 @@ Query the ledger for the current identity’s balance (base units):
 ```bash
 cargo run -- --identity alice balance
 ```
+
+### Transfer KINIC
+
+Transfer KINIC to another principal:
+
+```bash
+cargo run -- --identity alice transfer \
+  --to 2vxsx-fae \
+  --amount 1.25 \
+  --yes
+```
+
+Notes:
+- `--yes` is required to execute the transfer.
+- `--amount` accepts KINIC decimal text and is converted to e8s internally.
+- The CLI fetches the current ledger fee for every transfer.
 
 ### Ask AI (LLM placeholder)
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -84,6 +84,7 @@ The TUI has five tabs.
 - `Settings`: view and change current connection info and saved settings
 
 The `Memories` tab opens first when the TUI starts.
+The local preferences shown in `Settings`, including the default memory, saved tags, and manually tracked memories, can also be managed from the CLI with `kinic-cli prefs ...`.
 
 ## Basic Controls
 

--- a/rust/cli_defs.rs
+++ b/rust/cli_defs.rs
@@ -67,6 +67,10 @@ pub enum Command {
     #[command(about = "List deployed memories. Requires --identity or --ii. Returns text output.")]
     List(ListArgs),
     #[command(
+        about = "Show details for a memory canister. Requires --identity or --ii. Returns text output."
+    )]
+    Show(ShowArgs),
+    #[command(
         about = "Insert text into an existing memory canister. Requires --identity or --ii. Returns text output."
     )]
     Insert(InsertArgs),
@@ -99,6 +103,10 @@ pub enum Command {
     )]
     Config(ConfigArgs),
     #[command(
+        about = "Rename a memory canister. Requires --identity or --ii. Returns text output."
+    )]
+    Rename(RenameArgs),
+    #[command(
         about = "Describe CLI capabilities for agents. Returns JSON.",
         after_help = "Returns:\n  JSON with top-level commands, auth requirements, output modes, and major arguments.\n\nExample:\n  kinic-cli capabilities"
     )]
@@ -120,6 +128,8 @@ pub enum Command {
         about = "Check KINIC token balance. Requires --identity or --ii. Returns text output."
     )]
     Balance(BalanceArgs),
+    #[command(about = "Transfer KINIC tokens. Requires --identity or --ii. Returns text output.")]
+    Transfer(TransferArgs),
     #[command(
         about = "Ask Kinic AI using memory search results. Requires --identity or --ii. Returns text output."
     )]
@@ -152,6 +162,16 @@ pub struct TuiArgs {}
 
 #[derive(Args, Debug)]
 pub struct ListArgs {}
+
+#[derive(Args, Debug)]
+pub struct ShowArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the memory canister to show"
+    )]
+    pub memory_id: String,
+}
 
 #[derive(Args, Debug)]
 #[command(group = ArgGroup::new("insert_input").required(true).args(["text", "file_path"]))]
@@ -237,13 +257,18 @@ pub struct ConvertPdfArgs {
 }
 
 #[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("search_target")
+        .required(true)
+        .multiple(false)
+        .args(["memory_id", "all"])
+))]
 pub struct SearchArgs {
-    #[arg(
-        long,
-        required = true,
-        help = "Principal of the memory canister to search"
-    )]
-    pub memory_id: String,
+    #[arg(long, help = "Principal of the memory canister to search")]
+    pub memory_id: Option<String>,
+
+    #[arg(long, help = "Search across every searchable memory canister")]
+    pub all: bool,
 
     #[arg(long, required = true, help = "Query text to embed and search")]
     pub query: String,
@@ -281,6 +306,36 @@ pub struct TaggedEmbeddingsArgs {
 
 #[derive(Args, Debug)]
 pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub command: ConfigCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommand {
+    #[command(about = "Manage users for a memory canister")]
+    Users(ConfigUsersArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigUsersArgs {
+    #[command(subcommand)]
+    pub command: ConfigUsersCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigUsersCommand {
+    #[command(about = "List users for a memory canister")]
+    List(MemoryIdArgs),
+    #[command(about = "Add a user to a memory canister")]
+    Add(ConfigUserWriteArgs),
+    #[command(about = "Change a user's role on a memory canister")]
+    Change(ConfigUserWriteArgs),
+    #[command(about = "Remove a user from a memory canister")]
+    Remove(ConfigUserRemoveArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigUserWriteArgs {
     #[arg(
         long,
         required = true,
@@ -290,11 +345,26 @@ pub struct ConfigArgs {
 
     #[arg(
         long,
-        value_names = ["USER_ID", "ROLE"],
-        num_args = 2,
-        help = "Add a user with role to the Kinic CLI config (placeholder)"
+        required = true,
+        help = "Principal to add or update, or anonymous"
     )]
-    pub add_user: Option<Vec<String>>,
+    pub principal: String,
+
+    #[arg(long, required = true, help = "Role: admin, writer, or reader")]
+    pub role: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigUserRemoveArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the target memory canister"
+    )]
+    pub memory_id: String,
+
+    #[arg(long, required = true, help = "Principal to remove, or anonymous")]
+    pub principal: String,
 }
 
 #[derive(Args, Debug)]
@@ -379,6 +449,19 @@ pub struct UpdateArgs {
 }
 
 #[derive(Args, Debug)]
+pub struct RenameArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the target memory canister"
+    )]
+    pub memory_id: String,
+
+    #[arg(long, required = true, help = "New memory name")]
+    pub name: String,
+}
+
+#[derive(Args, Debug)]
 pub struct ResetArgs {
     #[arg(
         long,
@@ -393,6 +476,18 @@ pub struct ResetArgs {
 
 #[derive(Args, Debug)]
 pub struct BalanceArgs {}
+
+#[derive(Args, Debug)]
+pub struct TransferArgs {
+    #[arg(long, required = true, help = "Recipient principal")]
+    pub to: String,
+
+    #[arg(long, required = true, help = "Amount in KINIC, e.g. 1 or 0.25")]
+    pub amount: String,
+
+    #[arg(long, help = "Confirm that the transfer should be executed")]
+    pub yes: bool,
+}
 
 #[derive(Args, Debug)]
 pub struct AskAiArgs {

--- a/rust/cli_defs.rs
+++ b/rust/cli_defs.rs
@@ -14,7 +14,8 @@ pub fn parse_identity_arg(value: &str) -> Result<String, String> {
 #[command(
     name = "kinic-cli",
     version,
-    about = "Kinic developer CLI for deploying and managing memories"
+    about = "Kinic developer CLI for memory operations and agent-friendly local preferences",
+    after_help = "Auth modes:\n  Network commands require --identity <NAME> or --ii unless noted otherwise.\n  The TUI requires --identity <NAME> and does not support --ii.\n\nAgent entrypoints:\n  kinic-cli capabilities\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id <MEMORY_ID>\n\nReturns:\n  capabilities and prefs commands return JSON.\n  Existing network commands keep their current text output."
 )]
 pub struct Cli {
     #[command(flatten)]
@@ -59,42 +60,83 @@ pub struct GlobalOpts {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    #[command(about = "Deploy a new memory canister via the launcher")]
+    #[command(
+        about = "Deploy a new memory canister. Requires --identity or --ii. Returns text output."
+    )]
     Create(CreateArgs),
-    #[command(about = "List deployed memories and their principals")]
+    #[command(about = "List deployed memories. Requires --identity or --ii. Returns text output.")]
     List(ListArgs),
-    #[command(about = "Insert text into an existing memory canister")]
+    #[command(
+        about = "Insert text into an existing memory canister. Requires --identity or --ii. Returns text output."
+    )]
     Insert(InsertArgs),
-    #[command(about = "Insert a precomputed embedding into a memory canister")]
+    #[command(
+        about = "Insert a precomputed embedding into a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     InsertRaw(InsertRawArgs),
-    #[command(about = "Insert a PDF (converted to markdown) into an existing memory canister")]
+    #[command(
+        about = "Insert a PDF converted to markdown into a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     InsertPdf(InsertPdfArgs),
-    #[command(about = "Convert a PDF to markdown and print it (no insert)")]
+    #[command(
+        about = "Convert a PDF to markdown and print it. No identity required. Returns text output."
+    )]
     ConvertPdf(ConvertPdfArgs),
-    #[command(about = "Search within a memory canister using embeddings")]
+    #[command(
+        about = "Search within a memory canister using embeddings. Requires --identity or --ii. Returns text output."
+    )]
     Search(SearchArgs),
-    #[command(about = "Search within a memory canister using a precomputed embedding")]
+    #[command(
+        about = "Search within a memory canister using a precomputed embedding. Requires --identity or --ii. Returns text output."
+    )]
     SearchRaw(SearchRawArgs),
-    #[command(about = "Fetch embeddings for a tag from a memory canister")]
+    #[command(
+        about = "Fetch embeddings for a tag from a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     TaggedEmbeddings(TaggedEmbeddingsArgs),
-    #[command(about = "Manage Kinic CLI configuration")]
+    #[command(
+        about = "Manage memory access control. Requires --identity or --ii. Returns text output."
+    )]
     Config(ConfigArgs),
-    #[command(about = "Update a memory canister instance")]
+    #[command(
+        about = "Describe CLI capabilities for agents. Returns JSON.",
+        after_help = "Returns:\n  JSON with top-level commands, auth requirements, output modes, and major arguments.\n\nExample:\n  kinic-cli capabilities"
+    )]
+    Capabilities(CapabilitiesArgs),
+    #[command(
+        about = "Manage local Kinic preferences shared with the TUI. All prefs commands return JSON.",
+        after_help = "Examples:\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai\n\nReturns:\n  show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n  mutations -> {\"resource\": string, \"action\": string, \"status\": \"updated\"|\"unchanged\", \"value\": string|null}"
+    )]
+    Prefs(PrefsArgs),
+    #[command(
+        about = "Update a memory canister instance. Requires --identity or --ii. Returns text output."
+    )]
     Update(UpdateArgs),
-    #[command(about = "Reset a memory canister and set embedding dimension")]
+    #[command(
+        about = "Reset a memory canister and set embedding dimension. Requires --identity or --ii. Returns text output."
+    )]
     Reset(ResetArgs),
-    #[command(about = "Check KINIC token balance for the current identity")]
+    #[command(
+        about = "Check KINIC token balance. Requires --identity or --ii. Returns text output."
+    )]
     Balance(BalanceArgs),
-    #[command(about = "Ask Kinic AI using memory search results (LLM placeholder)")]
+    #[command(
+        about = "Ask Kinic AI using memory search results. Requires --identity or --ii. Returns text output."
+    )]
     AskAi(AskAiArgs),
-    #[command(about = "Login via Internet Identity and store a delegation")]
+    #[command(
+        about = "Login via Internet Identity and store a delegation. No identity required. Returns text output."
+    )]
     Login(LoginArgs),
     #[command(
-        about = "Launch the Kinic terminal UI (requires global --identity)",
-        after_help = "Required invocation:\n  kinic-cli --identity <IDENTITY> tui"
+        about = "Launch the Kinic terminal UI. Requires global --identity. --ii is not supported. Returns an interactive TUI, not JSON.",
+        after_help = "Requires:\n  kinic-cli --identity <IDENTITY> tui\n\nReturns:\n  Interactive terminal UI.\n\nExample:\n  kinic-cli --identity alice tui"
     )]
     Tui(TuiArgs),
 }
+
+#[derive(Args, Debug, Default)]
+pub struct CapabilitiesArgs {}
 
 #[derive(Args, Debug)]
 pub struct CreateArgs {
@@ -253,6 +295,77 @@ pub struct ConfigArgs {
         help = "Add a user with role to the Kinic CLI config (placeholder)"
     )]
     pub add_user: Option<Vec<String>>,
+}
+
+#[derive(Args, Debug)]
+pub struct PrefsArgs {
+    #[command(subcommand)]
+    pub command: PrefsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PrefsCommand {
+    #[command(
+        about = "Show local preferences shared with the TUI. Returns JSON.",
+        after_help = "Returns:\n  {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n\nExample:\n  kinic-cli prefs show"
+    )]
+    Show,
+    #[command(
+        about = "Set the default memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"default_memory_id\", \"action\": \"set\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    SetDefaultMemory(SetDefaultMemoryArgs),
+    #[command(
+        about = "Clear the default memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"default_memory_id\", \"action\": \"clear\", \"status\": \"updated\"|\"unchanged\", \"value\": null}\n\nExample:\n  kinic-cli prefs clear-default-memory"
+    )]
+    ClearDefaultMemory,
+    #[command(
+        about = "Add a saved tag. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"saved_tags\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs add-tag --tag quarterly_report"
+    )]
+    AddTag(TagArgs),
+    #[command(
+        about = "Remove a saved tag. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"saved_tags\", \"action\": \"remove\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs remove-tag --tag quarterly_report"
+    )]
+    RemoveTag(TagArgs),
+    #[command(
+        about = "Add a manually tracked memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    AddMemory(MemoryIdArgs),
+    #[command(
+        about = "Remove a manually tracked memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"remove\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    RemoveMemory(MemoryIdArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SetDefaultMemoryArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the default memory canister"
+    )]
+    pub memory_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct TagArgs {
+    #[arg(long, required = true, help = "Tag value to add or remove")]
+    pub tag: String,
+}
+
+#[derive(Args, Debug)]
+pub struct MemoryIdArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the memory canister to add or remove"
+    )]
+    pub memory_id: String,
 }
 
 #[derive(Args, Debug)]

--- a/rust/cli_defs.rs
+++ b/rust/cli_defs.rs
@@ -113,7 +113,7 @@ pub enum Command {
     Capabilities(CapabilitiesArgs),
     #[command(
         about = "Manage local Kinic preferences shared with the TUI. All prefs commands return JSON.",
-        after_help = "Examples:\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai\n\nReturns:\n  show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n  mutations -> {\"resource\": string, \"action\": string, \"status\": \"updated\"|\"unchanged\", \"value\": string|null}"
+        after_help = "Examples:\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai\n  kinic-cli prefs set-chat-overall-top-k --value 10\n\nReturns:\n  show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[], \"chat_overall_top_k\": integer, \"chat_per_memory_cap\": integer, \"chat_mmr_lambda\": integer}\n  mutations -> {\"resource\": string, \"action\": string, \"status\": \"updated\"|\"unchanged\", \"value\": string|integer|null}"
     )]
     Prefs(PrefsArgs),
     #[command(
@@ -377,7 +377,7 @@ pub struct PrefsArgs {
 pub enum PrefsCommand {
     #[command(
         about = "Show local preferences shared with the TUI. Returns JSON.",
-        after_help = "Returns:\n  {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n\nExample:\n  kinic-cli prefs show"
+        after_help = "Returns:\n  {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[], \"chat_overall_top_k\": integer, \"chat_per_memory_cap\": integer, \"chat_mmr_lambda\": integer}\n\nExample:\n  kinic-cli prefs show"
     )]
     Show,
     #[command(
@@ -402,14 +402,29 @@ pub enum PrefsCommand {
     RemoveTag(TagArgs),
     #[command(
         about = "Add a manually tracked memory id. Returns JSON.",
-        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExamples:\n  kinic-cli prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai\n  kinic-cli --identity alice prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai --validate"
     )]
-    AddMemory(MemoryIdArgs),
+    AddMemory(AddMemoryArgs),
     #[command(
         about = "Remove a manually tracked memory id. Returns JSON.",
         after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"remove\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
     )]
     RemoveMemory(MemoryIdArgs),
+    #[command(
+        about = "Set the all-memories chat retrieval result limit. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"chat_overall_top_k\", \"action\": \"set\", \"status\": \"updated\"|\"unchanged\", \"value\": integer}\n\nExample:\n  kinic-cli prefs set-chat-overall-top-k --value 10"
+    )]
+    SetChatOverallTopK(ChatOverallTopKArgs),
+    #[command(
+        about = "Set the per-memory chat retrieval cap. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"chat_per_memory_cap\", \"action\": \"set\", \"status\": \"updated\"|\"unchanged\", \"value\": integer}\n\nExample:\n  kinic-cli prefs set-chat-per-memory-cap --value 4"
+    )]
+    SetChatPerMemoryCap(ChatPerMemoryCapArgs),
+    #[command(
+        about = "Set the chat retrieval MMR lambda percentage. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"chat_mmr_lambda\", \"action\": \"set\", \"status\": \"updated\"|\"unchanged\", \"value\": integer}\n\nExample:\n  kinic-cli prefs set-chat-mmr-lambda --value 80"
+    )]
+    SetChatMmrLambda(ChatMmrLambdaArgs),
 }
 
 #[derive(Args, Debug)]
@@ -436,6 +451,52 @@ pub struct MemoryIdArgs {
         help = "Principal of the memory canister to add or remove"
     )]
     pub memory_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct AddMemoryArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the memory canister to add"
+    )]
+    pub memory_id: String,
+
+    #[arg(
+        long,
+        help = "Validate access through get_users() using --identity or --ii before saving"
+    )]
+    pub validate: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ChatOverallTopKArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Number of documents to keep after global reranking"
+    )]
+    pub value: usize,
+}
+
+#[derive(Args, Debug)]
+pub struct ChatPerMemoryCapArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Maximum documents to keep from each memory"
+    )]
+    pub value: usize,
+}
+
+#[derive(Args, Debug)]
+pub struct ChatMmrLambdaArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "MMR lambda percentage, one of 60, 70, 80, 90"
+    )]
+    pub value: u8,
 }
 
 #[derive(Args, Debug)]

--- a/rust/cli_defs.rs
+++ b/rust/cli_defs.rs
@@ -160,8 +160,11 @@ pub struct CreateArgs {
 #[derive(Args, Debug, Default)]
 pub struct TuiArgs {}
 
-#[derive(Args, Debug)]
-pub struct ListArgs {}
+#[derive(Args, Debug, Default)]
+pub struct ListArgs {
+    #[arg(long, help = "Return machine-readable JSON output")]
+    pub json: bool,
+}
 
 #[derive(Args, Debug)]
 pub struct ShowArgs {
@@ -171,6 +174,9 @@ pub struct ShowArgs {
         help = "Principal of the memory canister to show"
     )]
     pub memory_id: String,
+
+    #[arg(long, help = "Return machine-readable JSON output")]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]
@@ -272,6 +278,9 @@ pub struct SearchArgs {
 
     #[arg(long, required = true, help = "Query text to embed and search")]
     pub query: String,
+
+    #[arg(long, help = "Return machine-readable JSON output")]
+    pub json: bool,
 }
 
 #[derive(Args, Debug)]

--- a/rust/commands/capabilities.rs
+++ b/rust/commands/capabilities.rs
@@ -1,0 +1,380 @@
+//! Agent-readable capability description for the Kinic CLI.
+//! Where: top-level `capabilities` command.
+//! What: builds JSON from clap command definitions plus a small semantic overlay.
+//! Why: reduces drift between CLI parsing and agent-facing discovery metadata.
+
+use anyhow::Result;
+use clap::{Arg, ArgGroup, Command, CommandFactory};
+use serde::Serialize;
+
+use crate::cli::{CapabilitiesArgs, Cli};
+
+pub fn handle(_args: CapabilitiesArgs) -> Result<()> {
+    let payload = CapabilitiesDocument::new();
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct CapabilitiesDocument {
+    cli: &'static str,
+    version: &'static str,
+    auth_summary: &'static str,
+    commands: Vec<CommandCapability>,
+}
+
+impl CapabilitiesDocument {
+    fn new() -> Self {
+        Self {
+            cli: "kinic-cli",
+            version: env!("CARGO_PKG_VERSION"),
+            auth_summary: "Network commands require --identity or --ii unless noted otherwise. The TUI requires --identity.",
+            commands: command_capabilities(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CommandCapability {
+    name: String,
+    summary: String,
+    requires_auth: bool,
+    auth_modes: Vec<&'static str>,
+    output_mode: &'static str,
+    interactive: bool,
+    arguments: Vec<ArgumentCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arg_groups: Vec<ArgGroupCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subcommands: Vec<SubcommandCapability>,
+}
+
+#[derive(Debug, Serialize)]
+struct SubcommandCapability {
+    name: String,
+    summary: String,
+    output_mode: &'static str,
+    arguments: Vec<ArgumentCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arg_groups: Vec<ArgGroupCapability>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ArgumentCapability {
+    name: String,
+    required: bool,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "ArgumentRelations::is_empty")]
+    relations: ArgumentRelations,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, Default)]
+struct ArgumentRelations {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requires: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conflicts: Vec<String>,
+}
+
+impl ArgumentRelations {
+    fn is_empty(&self) -> bool {
+        self.requires.is_empty() && self.conflicts.is_empty()
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ArgGroupCapability {
+    id: String,
+    required: bool,
+    multiple: bool,
+    members: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+struct CommandMetadata {
+    auth_modes: &'static [&'static str],
+    output_mode: &'static str,
+    interactive: bool,
+}
+
+fn command_capabilities() -> Vec<CommandCapability> {
+    Cli::command()
+        .get_subcommands()
+        .map(|command| {
+            let metadata = command_metadata(command.get_name());
+            CommandCapability {
+                name: command.get_name().to_string(),
+                summary: command_summary(command),
+                requires_auth: !metadata.auth_modes.is_empty(),
+                auth_modes: metadata.auth_modes.to_vec(),
+                output_mode: metadata.output_mode,
+                interactive: metadata.interactive,
+                arguments: argument_capabilities(command, command.get_name()),
+                arg_groups: arg_group_capabilities(command),
+                subcommands: subcommand_capabilities(command, metadata.output_mode),
+            }
+        })
+        .collect()
+}
+
+fn subcommand_capabilities(
+    command: &Command,
+    parent_output_mode: &'static str,
+) -> Vec<SubcommandCapability> {
+    command
+        .get_subcommands()
+        .map(|subcommand| {
+            let path = format!("{}.{}", command.get_name(), subcommand.get_name());
+            SubcommandCapability {
+                name: subcommand.get_name().to_string(),
+                summary: command_summary(subcommand),
+                output_mode: subcommand_output_mode(&path, parent_output_mode),
+                arguments: argument_capabilities(subcommand, &path),
+                arg_groups: arg_group_capabilities(subcommand),
+            }
+        })
+        .collect()
+}
+
+fn argument_capabilities(command: &Command, path: &str) -> Vec<ArgumentCapability> {
+    command
+        .get_arguments()
+        .filter_map(|arg| public_argument(command, arg, path))
+        .collect()
+}
+
+fn public_argument(command: &Command, arg: &Arg, path: &str) -> Option<ArgumentCapability> {
+    let name = arg.get_id().as_str();
+    if matches!(name, "help" | "version") || arg.get_long().is_none() {
+        return None;
+    }
+    Some(ArgumentCapability {
+        name: name.to_string(),
+        required: arg.is_required_set(),
+        kind: argument_kind(path, name),
+        relations: argument_relations(command, arg, path),
+    })
+}
+
+fn argument_relations(command: &Command, arg: &Arg, path: &str) -> ArgumentRelations {
+    let mut relations = manual_argument_relations(path, arg.get_id().as_str());
+    relations.conflicts.extend(
+        command
+            .get_arg_conflicts_with(arg)
+            .into_iter()
+            .filter(|conflict| conflict.get_long().is_some())
+            .map(|conflict| conflict.get_id().as_str().to_string()),
+    );
+    relations
+}
+
+fn manual_argument_relations(path: &str, name: &str) -> ArgumentRelations {
+    let _ = (path, name);
+    ArgumentRelations::default()
+}
+
+fn command_summary(command: &Command) -> String {
+    command
+        .get_long_about()
+        .or_else(|| command.get_about())
+        .map(|value| value.to_string())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn arg_group_capabilities(command: &Command) -> Vec<ArgGroupCapability> {
+    let public_argument_names: Vec<&str> = command
+        .get_arguments()
+        .filter(|arg| arg.get_long().is_some())
+        .map(|arg| arg.get_id().as_str())
+        .collect();
+    command
+        .get_groups()
+        .filter(|group| is_public_arg_group(group, &public_argument_names))
+        .map(public_arg_group)
+        .collect()
+}
+
+fn public_arg_group(group: &ArgGroup) -> ArgGroupCapability {
+    let mut group = group.clone();
+    ArgGroupCapability {
+        id: group.get_id().as_str().to_string(),
+        required: group.is_required_set(),
+        multiple: group.is_multiple(),
+        members: group
+            .get_args()
+            .map(|member| member.as_str().to_string())
+            .collect(),
+    }
+}
+
+fn is_public_arg_group(group: &ArgGroup, public_argument_names: &[&str]) -> bool {
+    let member_names: Vec<&str> = group.get_args().map(|member| member.as_str()).collect();
+    !(group.get_id().as_str().ends_with("Args")
+        && !group.is_required_set()
+        && member_names == public_argument_names)
+}
+
+fn command_metadata(name: &str) -> CommandMetadata {
+    match name {
+        "convert-pdf" | "capabilities" | "prefs" | "login" => CommandMetadata {
+            auth_modes: &[],
+            output_mode: if name == "capabilities" || name == "prefs" {
+                "json"
+            } else {
+                "text"
+            },
+            interactive: false,
+        },
+        "tui" => CommandMetadata {
+            auth_modes: &["identity"],
+            output_mode: "interactive",
+            interactive: true,
+        },
+        _ => CommandMetadata {
+            auth_modes: &["identity", "ii"],
+            output_mode: "text",
+            interactive: false,
+        },
+    }
+}
+
+fn subcommand_output_mode(path: &str, parent_output_mode: &'static str) -> &'static str {
+    match path {
+        "prefs.show"
+        | "prefs.set-default-memory"
+        | "prefs.clear-default-memory"
+        | "prefs.add-tag"
+        | "prefs.remove-tag"
+        | "prefs.add-memory"
+        | "prefs.remove-memory" => "json",
+        _ => parent_output_mode,
+    }
+}
+
+fn argument_kind(path: &str, name: &str) -> &'static str {
+    match (path, name) {
+        (_, "memory_id") => "principal",
+        (_, "file_path") => "path",
+        (_, "embedding") => "json_array",
+        (_, "top_k" | "dim") => "integer",
+        ("config", "add_user") => "principal_role_pair",
+        _ => "string",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, CommandFactory};
+
+    use super::*;
+    use crate::cli::Cli;
+
+    #[test]
+    fn capabilities_document_matches_top_level_clap_commands() {
+        let document = CapabilitiesDocument::new();
+        let clap_names: Vec<String> = Cli::command()
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect();
+        let capability_names: Vec<String> = document
+            .commands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect();
+
+        assert_eq!(capability_names, clap_names);
+    }
+
+    #[test]
+    fn capabilities_document_describes_prefs_subcommands_from_clap() {
+        let document = CapabilitiesDocument::new();
+        let prefs = document
+            .commands
+            .iter()
+            .find(|command| command.name == "prefs")
+            .expect("prefs command should exist");
+        let clap = Cli::command();
+        let clap_prefs = clap
+            .get_subcommands()
+            .find(|command| command.get_name() == "prefs")
+            .expect("prefs should exist in clap");
+        let clap_subcommands: Vec<String> = clap_prefs
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect();
+        let capability_subcommands: Vec<String> = prefs
+            .subcommands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect();
+
+        assert_eq!(capability_subcommands, clap_subcommands);
+        assert_eq!(prefs.output_mode, "json");
+    }
+
+    #[test]
+    fn capabilities_document_marks_tui_as_interactive_identity_only() {
+        let document = CapabilitiesDocument::new();
+        let tui = document
+            .commands
+            .iter()
+            .find(|command| command.name == "tui")
+            .expect("tui command should exist");
+
+        assert!(tui.requires_auth);
+        assert_eq!(tui.auth_modes, ["identity"]);
+        assert_eq!(tui.output_mode, "interactive");
+        assert!(tui.interactive);
+    }
+
+    #[test]
+    fn capabilities_document_includes_insert_arg_group_constraints() {
+        let document = CapabilitiesDocument::new();
+        let insert = document
+            .commands
+            .iter()
+            .find(|command| command.name == "insert")
+            .expect("insert command should exist");
+
+        assert_eq!(
+            insert.arg_groups,
+            vec![ArgGroupCapability {
+                id: "insert_input".to_string(),
+                required: true,
+                multiple: false,
+                members: vec!["text".to_string(), "file_path".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn argument_relations_capture_public_conflicts() {
+        let command = Command::new("demo")
+            .arg(Arg::new("alpha").long("alpha").conflicts_with("beta"))
+            .arg(Arg::new("beta").long("beta"));
+        let alpha = command
+            .get_arguments()
+            .find(|arg| arg.get_id().as_str() == "alpha")
+            .expect("alpha should exist");
+
+        let relations = argument_relations(&command, alpha, "demo");
+
+        assert_eq!(
+            relations,
+            ArgumentRelations {
+                requires: Vec::new(),
+                conflicts: vec!["beta".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn manual_argument_relations_default_to_empty_overlay() {
+        assert_eq!(
+            manual_argument_relations("insert", "text"),
+            ArgumentRelations::default()
+        );
+    }
+}

--- a/rust/commands/capabilities.rs
+++ b/rust/commands/capabilities.rs
@@ -274,6 +274,10 @@ fn argument_kind(path: &str, name: &str) -> &'static str {
     }
 
     match (path, name) {
+        ("prefs.add-memory", "validate") => "boolean",
+        ("prefs.set-chat-overall-top-k", "value")
+        | ("prefs.set-chat-per-memory-cap", "value")
+        | ("prefs.set-chat-mmr-lambda", "value") => "integer",
         (_, "memory_id") => "principal",
         (_, "file_path") => "path",
         (_, "embedding") => "json_array",

--- a/rust/commands/capabilities.rs
+++ b/rust/commands/capabilities.rs
@@ -57,6 +57,8 @@ struct SubcommandCapability {
     arguments: Vec<ArgumentCapability>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     arg_groups: Vec<ArgGroupCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subcommands: Vec<SubcommandCapability>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -121,16 +123,29 @@ fn subcommand_capabilities(
     command: &Command,
     parent_output_mode: &'static str,
 ) -> Vec<SubcommandCapability> {
+    subcommand_capabilities_with_path(command, command.get_name(), parent_output_mode)
+}
+
+fn subcommand_capabilities_with_path(
+    command: &Command,
+    parent_path: &str,
+    parent_output_mode: &'static str,
+) -> Vec<SubcommandCapability> {
     command
         .get_subcommands()
         .map(|subcommand| {
-            let path = format!("{}.{}", command.get_name(), subcommand.get_name());
+            let path = format!("{parent_path}.{}", subcommand.get_name());
             SubcommandCapability {
                 name: subcommand.get_name().to_string(),
                 summary: command_summary(subcommand),
                 output_mode: subcommand_output_mode(&path, parent_output_mode),
                 arguments: argument_capabilities(subcommand, &path),
                 arg_groups: arg_group_capabilities(subcommand),
+                subcommands: subcommand_capabilities_with_path(
+                    subcommand,
+                    &path,
+                    subcommand_output_mode(&path, parent_output_mode),
+                ),
             }
         })
         .collect()
@@ -254,6 +269,10 @@ fn subcommand_output_mode(path: &str, parent_output_mode: &'static str) -> &'sta
 }
 
 fn argument_kind(path: &str, name: &str) -> &'static str {
+    if name == "all" && path == "search" {
+        return "boolean";
+    }
+
     match (path, name) {
         (_, "memory_id") => "principal",
         (_, "file_path") => "path",
@@ -312,6 +331,28 @@ mod tests {
 
         assert_eq!(capability_subcommands, clap_subcommands);
         assert_eq!(prefs.output_mode, "json");
+    }
+
+    #[test]
+    fn capabilities_document_includes_nested_config_user_subcommands() {
+        let document = CapabilitiesDocument::new();
+        let config = document
+            .commands
+            .iter()
+            .find(|command| command.name == "config")
+            .expect("config command should exist");
+        let users = config
+            .subcommands
+            .iter()
+            .find(|subcommand| subcommand.name == "users")
+            .expect("config users subcommand should exist");
+        let leaf_names: Vec<&str> = users
+            .subcommands
+            .iter()
+            .map(|subcommand| subcommand.name.as_str())
+            .collect();
+
+        assert_eq!(leaf_names, vec!["list", "add", "change", "remove"]);
     }
 
     #[test]
@@ -376,5 +417,21 @@ mod tests {
             manual_argument_relations("insert", "text"),
             ArgumentRelations::default()
         );
+    }
+
+    #[test]
+    fn argument_kind_marks_search_all_as_boolean() {
+        let command = crate::cli::Cli::command();
+        let search = command
+            .get_subcommands()
+            .find(|subcommand| subcommand.get_name() == "search")
+            .expect("search command should exist");
+        let all = search
+            .get_arguments()
+            .find(|arg| arg.get_id().as_str() == "all")
+            .expect("all arg should exist");
+
+        assert!(matches!(all.get_action(), clap::ArgAction::SetTrue));
+        assert_eq!(argument_kind("search", "all"), "boolean");
     }
 }

--- a/rust/commands/capabilities.rs
+++ b/rust/commands/capabilities.rs
@@ -41,6 +41,7 @@ struct CommandCapability {
     requires_auth: bool,
     auth_modes: Vec<&'static str>,
     output_mode: &'static str,
+    supported_output_modes: Vec<&'static str>,
     interactive: bool,
     arguments: Vec<ArgumentCapability>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -54,6 +55,7 @@ struct SubcommandCapability {
     name: String,
     summary: String,
     output_mode: &'static str,
+    supported_output_modes: Vec<&'static str>,
     arguments: Vec<ArgumentCapability>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     arg_groups: Vec<ArgGroupCapability>,
@@ -96,6 +98,7 @@ struct ArgGroupCapability {
 struct CommandMetadata {
     auth_modes: &'static [&'static str],
     output_mode: &'static str,
+    supported_output_modes: &'static [&'static str],
     interactive: bool,
 }
 
@@ -110,6 +113,7 @@ fn command_capabilities() -> Vec<CommandCapability> {
                 requires_auth: !metadata.auth_modes.is_empty(),
                 auth_modes: metadata.auth_modes.to_vec(),
                 output_mode: metadata.output_mode,
+                supported_output_modes: metadata.supported_output_modes.to_vec(),
                 interactive: metadata.interactive,
                 arguments: argument_capabilities(command, command.get_name()),
                 arg_groups: arg_group_capabilities(command),
@@ -139,6 +143,10 @@ fn subcommand_capabilities_with_path(
                 name: subcommand.get_name().to_string(),
                 summary: command_summary(subcommand),
                 output_mode: subcommand_output_mode(&path, parent_output_mode),
+                supported_output_modes: subcommand_supported_output_modes(
+                    &path,
+                    parent_output_mode,
+                ),
                 arguments: argument_capabilities(subcommand, &path),
                 arg_groups: arg_group_capabilities(subcommand),
                 subcommands: subcommand_capabilities_with_path(
@@ -240,16 +248,27 @@ fn command_metadata(name: &str) -> CommandMetadata {
             } else {
                 "text"
             },
+            supported_output_modes: if name == "capabilities" || name == "prefs" {
+                &["json"]
+            } else {
+                &["text"]
+            },
             interactive: false,
         },
         "tui" => CommandMetadata {
             auth_modes: &["identity"],
             output_mode: "interactive",
+            supported_output_modes: &["interactive"],
             interactive: true,
         },
         _ => CommandMetadata {
             auth_modes: &["identity", "ii"],
             output_mode: "text",
+            supported_output_modes: if matches!(name, "list" | "show" | "search") {
+                &["text", "json"]
+            } else {
+                &["text"]
+            },
             interactive: false,
         },
     }
@@ -268,8 +287,30 @@ fn subcommand_output_mode(path: &str, parent_output_mode: &'static str) -> &'sta
     }
 }
 
+fn subcommand_supported_output_modes(
+    path: &str,
+    parent_output_mode: &'static str,
+) -> Vec<&'static str> {
+    match path {
+        "prefs.show"
+        | "prefs.set-default-memory"
+        | "prefs.clear-default-memory"
+        | "prefs.add-tag"
+        | "prefs.remove-tag"
+        | "prefs.add-memory"
+        | "prefs.remove-memory"
+        | "prefs.set-chat-overall-top-k"
+        | "prefs.set-chat-per-memory-cap"
+        | "prefs.set-chat-mmr-lambda" => vec!["json"],
+        _ => vec![parent_output_mode],
+    }
+}
+
 fn argument_kind(path: &str, name: &str) -> &'static str {
-    if name == "all" && path == "search" {
+    if matches!(
+        (path, name),
+        ("search", "all") | ("list", "json") | ("show", "json") | ("search", "json")
+    ) {
         return "boolean";
     }
 
@@ -335,6 +376,7 @@ mod tests {
 
         assert_eq!(capability_subcommands, clap_subcommands);
         assert_eq!(prefs.output_mode, "json");
+        assert_eq!(prefs.supported_output_modes, vec!["json"]);
     }
 
     #[test]
@@ -371,6 +413,7 @@ mod tests {
         assert!(tui.requires_auth);
         assert_eq!(tui.auth_modes, ["identity"]);
         assert_eq!(tui.output_mode, "interactive");
+        assert_eq!(tui.supported_output_modes, vec!["interactive"]);
         assert!(tui.interactive);
     }
 
@@ -437,5 +480,12 @@ mod tests {
 
         assert!(matches!(all.get_action(), clap::ArgAction::SetTrue));
         assert_eq!(argument_kind("search", "all"), "boolean");
+    }
+
+    #[test]
+    fn command_metadata_marks_json_capable_read_commands() {
+        let metadata = command_metadata("search");
+        assert_eq!(metadata.output_mode, "text");
+        assert_eq!(metadata.supported_output_modes, ["text", "json"]);
     }
 }

--- a/rust/commands/config.rs
+++ b/rust/commands/config.rs
@@ -1,82 +1,151 @@
-use anyhow::{Context, Result, bail};
-use ic_agent::export::Principal;
+//! Memory access control commands for the Kinic CLI.
+//! Where: handles `kinic-cli config users ...`.
+//! What: lists, adds, changes, and removes memory users with shared validation rules.
+//! Why: keep access-control operations consistent with the TUI while exposing them in the CLI.
+
+use anyhow::{Context, Result};
 use tracing::info;
 
-use crate::{cli::ConfigArgs, memory_client_builder::build_memory_client};
+use crate::{
+    cli::{
+        ConfigArgs, ConfigCommand, ConfigUserRemoveArgs, ConfigUserWriteArgs, ConfigUsersCommand,
+    },
+    clients::launcher::LauncherClient,
+    memory_client_builder::build_memory_client,
+    shared::access::{format_role, visible_memory_users},
+};
 
-use super::CommandContext;
+use super::{
+    CommandContext,
+    helpers::{MemoryRole, parse_user_principal, validate_role_assignment},
+};
 
-pub async fn handle(args: ConfigArgs, _ctx: &CommandContext) -> Result<()> {
-    let Some(values) = args.add_user else {
-        bail!("config requires an operation; use --add-user <user_id> <role>");
-    };
+pub async fn handle(args: ConfigArgs, ctx: &CommandContext) -> Result<()> {
+    match args.command {
+        ConfigCommand::Users(users) => match users.command {
+            ConfigUsersCommand::List(args) => list_users(&args.memory_id, ctx).await,
+            ConfigUsersCommand::Add(args) => write_user(args, ctx, ConfigWriteAction::Add).await,
+            ConfigUsersCommand::Change(args) => {
+                write_user(args, ctx, ConfigWriteAction::Change).await
+            }
+            ConfigUsersCommand::Remove(args) => remove_user(args, ctx).await,
+        },
+    }
+}
 
-    let (principal, role) = parse_add_user(values)?;
-    let client = build_memory_client(&_ctx.agent_factory, &args.memory_id).await?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigWriteAction {
+    Add,
+    Change,
+}
 
-    client
-        .add_new_user(principal, role.code())
+impl ConfigWriteAction {
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Add => "added",
+            Self::Change => "changed",
+        }
+    }
+}
+
+async fn list_users(memory_id: &str, ctx: &CommandContext) -> Result<()> {
+    let agent = ctx.agent_factory.build().await?;
+    let launcher_id = LauncherClient::new(agent).launcher_id().to_text();
+    let client = build_memory_client(&ctx.agent_factory, memory_id).await?;
+    let users = client
+        .get_users()
         .await
-        .context("Failed to add new user to memory canister")?;
+        .context("Failed to fetch users from memory canister")?;
+    let visible_users = visible_memory_users(users, &launcher_id);
 
-    info!(
-        canister_id = %client.canister_id(),
-        role = ?role,
-        "added user to memory canister"
-    );
+    println!("Users for memory canister {}:", client.canister_id());
+    if visible_users.is_empty() {
+        println!("- (none)");
+        return Ok(());
+    }
 
-    println!("User added to memory canister with role {role:?}");
+    for user in visible_users {
+        println!("- {}: {}", user.principal_id, format_role(user.role_code));
+    }
     Ok(())
 }
 
-#[derive(Debug)]
-enum Role {
-    Admin,
-    Writer,
-    Reader,
-}
+async fn write_user(
+    args: ConfigUserWriteArgs,
+    ctx: &CommandContext,
+    action: ConfigWriteAction,
+) -> Result<()> {
+    let principal = parse_user_principal(&args.principal)?;
+    let role = MemoryRole::from_str(&args.role)?;
+    validate_role_assignment(&args.principal, role)?;
 
-impl Role {
-    fn from_str(value: &str) -> Result<Self> {
-        match value.to_lowercase().as_str() {
-            "admin" => Ok(Self::Admin),
-            "writer" => Ok(Self::Writer),
-            "reader" => Ok(Self::Reader),
-            _ => bail!("role must be one of: admin, writer, reader"),
+    let client = build_memory_client(&ctx.agent_factory, &args.memory_id).await?;
+    match action {
+        ConfigWriteAction::Add => {
+            client
+                .add_new_user(principal, role.code())
+                .await
+                .context("Failed to add user to memory canister")?;
+        }
+        ConfigWriteAction::Change => {
+            client
+                .remove_user(principal)
+                .await
+                .context("Failed to remove existing user from memory canister")?;
+            client
+                .add_new_user(principal, role.code())
+                .await
+                .context("Failed to add updated user role to memory canister")?;
         }
     }
 
-    fn code(&self) -> u8 {
-        match self {
-            Role::Admin => 1,
-            Role::Writer => 2,
-            Role::Reader => 3,
-        }
-    }
+    info!(
+        canister_id = %client.canister_id(),
+        principal = %args.principal,
+        role = role.as_str(),
+        action = action.verb(),
+        "updated memory user access"
+    );
+
+    println!(
+        "User {} on memory canister {} with role {}",
+        action.verb(),
+        client.canister_id(),
+        role.as_str()
+    );
+    Ok(())
 }
 
-fn parse_add_user(values: Vec<String>) -> Result<(Principal, Role)> {
-    if values.len() != 2 {
-        bail!("--add-user expects exactly two values: <user_id> <role>");
+async fn remove_user(args: ConfigUserRemoveArgs, ctx: &CommandContext) -> Result<()> {
+    let principal = parse_user_principal(&args.principal)?;
+    let client = build_memory_client(&ctx.agent_factory, &args.memory_id).await?;
+
+    client
+        .remove_user(principal)
+        .await
+        .context("Failed to remove user from memory canister")?;
+
+    info!(
+        canister_id = %client.canister_id(),
+        principal = %args.principal,
+        "removed memory user access"
+    );
+
+    println!(
+        "User removed from memory canister {}: {}",
+        client.canister_id(),
+        args.principal.trim()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_write_action_uses_expected_verbs() {
+        assert_eq!(ConfigWriteAction::Add.verb(), "added");
+        assert_eq!(ConfigWriteAction::Change.verb(), "changed");
     }
-
-    let user_id = values
-        .first()
-        .context("missing user_id value for --add-user")?;
-    let role = values.get(1).context("missing role value for --add-user")?;
-
-    let user = if user_id == "anonymous" {
-        Principal::anonymous()
-    } else {
-        Principal::from_text(user_id)
-            .with_context(|| format!("invalid principal text: {user_id}"))?
-    };
-
-    let role = Role::from_str(role)?;
-
-    if matches!(role, Role::Admin) && user_id == "anonymous" {
-        bail!("cannot grant admin role to anonymous");
-    }
-
-    Ok((user, role))
 }

--- a/rust/commands/helpers.rs
+++ b/rust/commands/helpers.rs
@@ -1,0 +1,6 @@
+//! Thin re-export for shared access helpers used by CLI command handlers.
+//! Where: imported by CLI commands under `commands/`.
+//! What: forwards to crate-level shared logic without keeping a second implementation.
+//! Why: allow incremental migration of command imports while centralizing behavior.
+
+pub use crate::shared::access::{MemoryRole, parse_user_principal, validate_role_assignment};

--- a/rust/commands/list.rs
+++ b/rust/commands/list.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ic_agent::export::Principal;
+use serde::Serialize;
 use tracing::info;
 
 use crate::{
@@ -13,31 +13,99 @@ pub async fn handle(_args: ListArgs, ctx: &CommandContext) -> Result<()> {
     let agent = ctx.agent_factory.build().await?;
     let client = LauncherClient::new(agent);
     let states = client.list_memories().await?;
+    let items = states.iter().filter_map(memory_item).collect::<Vec<_>>();
 
-    let principals: Vec<Principal> = states
-        .iter()
-        .filter_map(memory_principal)
-        .cloned()
-        .collect();
-
-    if principals.is_empty() {
-        println!("No memories found.");
+    if _args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&ListOutput {
+                count: items.len(),
+                items,
+            })?
+        );
     } else {
-        println!("Memories:");
-        for principal in principals {
-            println!("- {principal}");
-        }
+        print_list_text(&items);
     }
 
     info!("listed memories");
     Ok(())
 }
 
-fn memory_principal(state: &State) -> Option<&Principal> {
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ListOutput {
+    count: usize,
+    items: Vec<ListItem>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ListItem {
+    memory_id: String,
+    status: &'static str,
+}
+
+fn memory_item(state: &State) -> Option<ListItem> {
     match state {
-        State::Installation(principal, _)
-        | State::SettingUp(principal)
-        | State::Running(principal) => Some(principal),
+        State::Installation(principal, _) => Some(ListItem {
+            memory_id: principal.to_text(),
+            status: "installation",
+        }),
+        State::SettingUp(principal) => Some(ListItem {
+            memory_id: principal.to_text(),
+            status: "setting_up",
+        }),
+        State::Running(principal) => Some(ListItem {
+            memory_id: principal.to_text(),
+            status: "running",
+        }),
         _ => None,
+    }
+}
+
+fn print_list_text(items: &[ListItem]) {
+    if items.is_empty() {
+        println!("No memories found.");
+    } else {
+        println!("Memories:");
+        for item in items {
+            println!("- {}", item.memory_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_agent::export::Principal;
+
+    #[test]
+    fn memory_item_uses_launcher_state_as_status() {
+        let installation = memory_item(&State::Installation(Principal::anonymous(), "x".into()))
+            .expect("installation item");
+        let setting_up = memory_item(&State::SettingUp(Principal::management_canister()))
+            .expect("setting_up item");
+        let running = memory_item(&State::Running(Principal::anonymous())).expect("running item");
+
+        assert_eq!(installation.status, "installation");
+        assert_eq!(setting_up.status, "setting_up");
+        assert_eq!(running.status, "running");
+    }
+
+    #[test]
+    fn list_output_serializes_with_count_and_items() {
+        let output = serde_json::to_value(ListOutput {
+            count: 1,
+            items: vec![ListItem {
+                memory_id: "aaaaa-aa".to_string(),
+                status: "running",
+            }],
+        })
+        .expect("list output should serialize");
+
+        assert_eq!(output["count"], serde_json::json!(1));
+        assert_eq!(
+            output["items"][0]["memory_id"],
+            serde_json::json!("aaaaa-aa")
+        );
+        assert_eq!(output["items"][0]["status"], serde_json::json!("running"));
     }
 }

--- a/rust/commands/mod.rs
+++ b/rust/commands/mod.rs
@@ -8,16 +8,20 @@ pub mod capabilities;
 pub mod config;
 pub mod convert_pdf;
 pub mod create;
+pub mod helpers;
 pub mod ii_login;
 pub mod insert;
 pub mod insert_pdf;
 pub mod insert_raw;
 pub mod list;
 pub mod prefs;
+pub mod rename;
 pub mod reset;
 pub mod search;
 pub mod search_raw;
+pub mod show;
 pub mod tagged_embeddings;
+pub mod transfer;
 pub mod update;
 
 #[derive(Clone)]
@@ -30,6 +34,7 @@ pub async fn run_command(command: Command, ctx: CommandContext) -> Result<()> {
     match command {
         Command::Create(args) => create::handle(args, &ctx).await,
         Command::List(args) => list::handle(args, &ctx).await,
+        Command::Show(args) => show::handle(args, &ctx).await,
         Command::Insert(args) => insert::handle(args, &ctx).await,
         Command::InsertRaw(args) => insert_raw::handle(args, &ctx).await,
         Command::InsertPdf(args) => insert_pdf::handle(args, &ctx).await,
@@ -38,6 +43,7 @@ pub async fn run_command(command: Command, ctx: CommandContext) -> Result<()> {
         Command::TaggedEmbeddings(args) => tagged_embeddings::handle(args, &ctx).await,
         Command::ConvertPdf(args) => convert_pdf::handle(args).await,
         Command::Config(args) => config::handle(args, &ctx).await,
+        Command::Rename(args) => rename::handle(args, &ctx).await,
         Command::Capabilities(_) => {
             unreachable!("capabilities command is handled before agent setup")
         }
@@ -45,6 +51,7 @@ pub async fn run_command(command: Command, ctx: CommandContext) -> Result<()> {
         Command::Update(args) => update::handle(args, &ctx).await,
         Command::Reset(args) => reset::handle(args, &ctx).await,
         Command::Balance(args) => balance::handle(args, &ctx).await,
+        Command::Transfer(args) => transfer::handle(args, &ctx).await,
         Command::AskAi(args) => ask_ai::handle(args, &ctx).await,
         Command::Login(args) => ii_login::handle(args, &ctx).await,
         Command::Tui(_) => unreachable!("TUI command is handled before command dispatch"),

--- a/rust/commands/mod.rs
+++ b/rust/commands/mod.rs
@@ -4,6 +4,7 @@ use crate::{agent::AgentFactory, cli::Command};
 
 pub mod ask_ai;
 pub mod balance;
+pub mod capabilities;
 pub mod config;
 pub mod convert_pdf;
 pub mod create;
@@ -12,6 +13,7 @@ pub mod insert;
 pub mod insert_pdf;
 pub mod insert_raw;
 pub mod list;
+pub mod prefs;
 pub mod reset;
 pub mod search;
 pub mod search_raw;
@@ -36,6 +38,10 @@ pub async fn run_command(command: Command, ctx: CommandContext) -> Result<()> {
         Command::TaggedEmbeddings(args) => tagged_embeddings::handle(args, &ctx).await,
         Command::ConvertPdf(args) => convert_pdf::handle(args).await,
         Command::Config(args) => config::handle(args, &ctx).await,
+        Command::Capabilities(_) => {
+            unreachable!("capabilities command is handled before agent setup")
+        }
+        Command::Prefs(_) => unreachable!("prefs command is handled before agent setup"),
         Command::Update(args) => update::handle(args, &ctx).await,
         Command::Reset(args) => reset::handle(args, &ctx).await,
         Command::Balance(args) => balance::handle(args, &ctx).await,

--- a/rust/commands/prefs.rs
+++ b/rust/commands/prefs.rs
@@ -1,26 +1,34 @@
 //! Local preferences management for CLI/TUI shared settings.
 //! Where: command handler used by the top-level `prefs` CLI subcommand.
-//! What: reads and writes the TUI-backed YAML preferences for default memory, tags, and manual memories.
+//! What: reads and writes the TUI-backed YAML preferences for defaults, tags, manual memories,
+//! and chat retrieval tuning.
 //! Why: keep the TUI as the single persistence layer while letting CLI users manage the same settings.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use ic_agent::export::Principal;
 use serde::Serialize;
 
 use crate::{
-    cli::{MemoryIdArgs, PrefsArgs, PrefsCommand, SetDefaultMemoryArgs, TagArgs},
+    cli::{
+        AddMemoryArgs, ChatMmrLambdaArgs, ChatOverallTopKArgs, ChatPerMemoryCapArgs, GlobalOpts,
+        MemoryIdArgs, PrefsArgs, PrefsCommand, SetDefaultMemoryArgs, TagArgs,
+    },
+    clients::memory::MemoryClient,
     preferences::{self, UserPreferences},
 };
 
-pub fn handle(args: PrefsArgs) -> Result<()> {
+pub async fn handle(args: PrefsArgs, global: &GlobalOpts) -> Result<()> {
     match args.command {
         PrefsCommand::Show => show_preferences(),
         PrefsCommand::SetDefaultMemory(args) => set_default_memory(args),
         PrefsCommand::ClearDefaultMemory => clear_default_memory(),
         PrefsCommand::AddTag(args) => add_tag(args),
         PrefsCommand::RemoveTag(args) => remove_tag(args),
-        PrefsCommand::AddMemory(args) => add_memory(args),
+        PrefsCommand::AddMemory(args) => add_memory(args, global).await,
         PrefsCommand::RemoveMemory(args) => remove_memory(args),
+        PrefsCommand::SetChatOverallTopK(args) => set_chat_overall_top_k(args),
+        PrefsCommand::SetChatPerMemoryCap(args) => set_chat_per_memory_cap(args),
+        PrefsCommand::SetChatMmrLambda(args) => set_chat_mmr_lambda(args),
     }
 }
 
@@ -96,7 +104,7 @@ fn remove_tag(args: TagArgs) -> Result<()> {
     print_json_response(PrefsResponse::updated("saved_tags", "remove", Some(tag)))
 }
 
-fn add_memory(args: MemoryIdArgs) -> Result<()> {
+async fn add_memory(args: AddMemoryArgs, global: &GlobalOpts) -> Result<()> {
     let memory_id = validate_memory_id(args.memory_id.as_str())?;
     let mut preferences = load_preferences()?;
     if preferences
@@ -109,6 +117,10 @@ fn add_memory(args: MemoryIdArgs) -> Result<()> {
             "add",
             Some(memory_id),
         ));
+    }
+
+    if args.validate {
+        validate_manual_memory_access(global, memory_id.as_str()).await?;
     }
 
     preferences.manual_memory_ids.push(memory_id.clone());
@@ -144,6 +156,46 @@ fn remove_memory(args: MemoryIdArgs) -> Result<()> {
     ))
 }
 
+fn set_chat_overall_top_k(args: ChatOverallTopKArgs) -> Result<()> {
+    let value = validate_chat_overall_top_k(args.value)?;
+    let mut preferences = load_preferences()?;
+    if preferences.chat_overall_top_k == value {
+        return print_json_response(PrefsResponse::unchanged("chat_overall_top_k", "set", value));
+    }
+
+    preferences.chat_overall_top_k = value;
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("chat_overall_top_k", "set", value))
+}
+
+fn set_chat_per_memory_cap(args: ChatPerMemoryCapArgs) -> Result<()> {
+    let value = validate_chat_per_memory_cap(args.value)?;
+    let mut preferences = load_preferences()?;
+    if preferences.chat_per_memory_cap == value {
+        return print_json_response(PrefsResponse::unchanged(
+            "chat_per_memory_cap",
+            "set",
+            value,
+        ));
+    }
+
+    preferences.chat_per_memory_cap = value;
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("chat_per_memory_cap", "set", value))
+}
+
+fn set_chat_mmr_lambda(args: ChatMmrLambdaArgs) -> Result<()> {
+    let value = validate_chat_mmr_lambda(args.value)?;
+    let mut preferences = load_preferences()?;
+    if preferences.chat_mmr_lambda == value {
+        return print_json_response(PrefsResponse::unchanged("chat_mmr_lambda", "set", value));
+    }
+
+    preferences.chat_mmr_lambda = value;
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("chat_mmr_lambda", "set", value))
+}
+
 fn load_preferences() -> Result<UserPreferences> {
     preferences::load_user_preferences().context("Failed to load shared TUI preferences")
 }
@@ -151,6 +203,30 @@ fn load_preferences() -> Result<UserPreferences> {
 fn save_preferences(user_preferences: &UserPreferences) -> Result<()> {
     let normalized = preferences::normalize_user_preferences(user_preferences.clone());
     preferences::save_user_preferences(&normalized).context("Failed to save shared TUI preferences")
+}
+
+async fn validate_manual_memory_access(global: &GlobalOpts, memory_id: &str) -> Result<()> {
+    let (agent_factory, _) = crate::build_cli_command_context(global)?;
+    let agent = agent_factory.build().await?;
+    let current_principal = agent
+        .get_principal()
+        .map_err(|error| anyhow!("Failed to derive principal for current identity: {error}"))?;
+    let memory = Principal::from_text(memory_id).context("Failed to parse memory canister id")?;
+    let client = MemoryClient::new(agent, memory);
+    let users = client
+        .get_users()
+        .await
+        .context("Failed to validate memory access via get_users")?;
+
+    if users.iter().any(|(principal_id, _)| {
+        Principal::from_text(principal_id)
+            .map(|principal| principal == current_principal)
+            .unwrap_or(false)
+    }) {
+        Ok(())
+    } else {
+        bail!("Current principal does not have access to this memory");
+    }
 }
 
 fn validate_memory_id(value: &str) -> Result<String> {
@@ -172,11 +248,63 @@ fn validate_tag(value: &str) -> Result<String> {
     Ok(trimmed.to_string())
 }
 
+fn validate_chat_overall_top_k(value: usize) -> Result<usize> {
+    if preferences::chat_result_limit_options().contains(&value) {
+        Ok(value)
+    } else {
+        bail!(
+            "chat overall top-k must be one of: {}",
+            display_options_usize(preferences::chat_result_limit_options())
+        );
+    }
+}
+
+fn validate_chat_per_memory_cap(value: usize) -> Result<usize> {
+    if preferences::chat_per_memory_limit_options().contains(&value) {
+        Ok(value)
+    } else {
+        bail!(
+            "chat per-memory cap must be one of: {}",
+            display_options_usize(preferences::chat_per_memory_limit_options())
+        );
+    }
+}
+
+fn validate_chat_mmr_lambda(value: u8) -> Result<u8> {
+    if preferences::chat_diversity_options().contains(&value) {
+        Ok(value)
+    } else {
+        bail!(
+            "chat mmr lambda must be one of: {}",
+            display_options_u8(preferences::chat_diversity_options())
+        );
+    }
+}
+
+fn display_options_usize(values: &[usize]) -> String {
+    values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn display_options_u8(values: &[u8]) -> String {
+    values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 #[derive(Debug, Serialize)]
 struct ShowPreferences {
     default_memory_id: Option<String>,
     saved_tags: Vec<String>,
     manual_memory_ids: Vec<String>,
+    chat_overall_top_k: usize,
+    chat_per_memory_cap: usize,
+    chat_mmr_lambda: u8,
 }
 
 impl From<UserPreferences> for ShowPreferences {
@@ -185,6 +313,9 @@ impl From<UserPreferences> for ShowPreferences {
             default_memory_id: value.default_memory_id,
             saved_tags: value.saved_tags,
             manual_memory_ids: value.manual_memory_ids,
+            chat_overall_top_k: value.chat_overall_top_k,
+            chat_per_memory_cap: value.chat_per_memory_cap,
+            chat_mmr_lambda: value.chat_mmr_lambda,
         }
     }
 }
@@ -301,7 +432,12 @@ mod tests {
         assert_eq!(serialized["default_memory_id"], serde_json::Value::Null);
         assert_eq!(serialized["saved_tags"], serde_json::json!([]));
         assert_eq!(serialized["manual_memory_ids"], serde_json::json!([]));
-        assert!(serialized.get("chat_overall_top_k").is_none());
+        assert_eq!(serialized["chat_overall_top_k"], DEFAULT_CHAT_OVERALL_TOP_K);
+        assert_eq!(
+            serialized["chat_per_memory_cap"],
+            DEFAULT_CHAT_PER_MEMORY_CAP
+        );
+        assert_eq!(serialized["chat_mmr_lambda"], DEFAULT_CHAT_MMR_LAMBDA);
     }
 
     #[test]
@@ -317,5 +453,32 @@ mod tests {
         assert_eq!(serialized["action"], "add");
         assert_eq!(serialized["status"], "updated");
         assert_eq!(serialized["value"], serde_json::json!("docs"));
+    }
+
+    #[test]
+    fn validate_chat_overall_top_k_rejects_unknown_values() {
+        let error = validate_chat_overall_top_k(5).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "chat overall top-k must be one of: 4, 6, 8, 10, 12"
+        );
+    }
+
+    #[test]
+    fn validate_chat_per_memory_cap_rejects_unknown_values() {
+        let error = validate_chat_per_memory_cap(5).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "chat per-memory cap must be one of: 1, 2, 3, 4"
+        );
+    }
+
+    #[test]
+    fn validate_chat_mmr_lambda_rejects_unknown_values() {
+        let error = validate_chat_mmr_lambda(50).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "chat mmr lambda must be one of: 60, 70, 80, 90"
+        );
     }
 }

--- a/rust/commands/prefs.rs
+++ b/rust/commands/prefs.rs
@@ -1,0 +1,321 @@
+//! Local preferences management for CLI/TUI shared settings.
+//! Where: command handler used by the top-level `prefs` CLI subcommand.
+//! What: reads and writes the TUI-backed YAML preferences for default memory, tags, and manual memories.
+//! Why: keep the TUI as the single persistence layer while letting CLI users manage the same settings.
+
+use anyhow::{Context, Result, bail};
+use ic_agent::export::Principal;
+use serde::Serialize;
+
+use crate::{
+    cli::{MemoryIdArgs, PrefsArgs, PrefsCommand, SetDefaultMemoryArgs, TagArgs},
+    preferences::{self, UserPreferences},
+};
+
+pub fn handle(args: PrefsArgs) -> Result<()> {
+    match args.command {
+        PrefsCommand::Show => show_preferences(),
+        PrefsCommand::SetDefaultMemory(args) => set_default_memory(args),
+        PrefsCommand::ClearDefaultMemory => clear_default_memory(),
+        PrefsCommand::AddTag(args) => add_tag(args),
+        PrefsCommand::RemoveTag(args) => remove_tag(args),
+        PrefsCommand::AddMemory(args) => add_memory(args),
+        PrefsCommand::RemoveMemory(args) => remove_memory(args),
+    }
+}
+
+fn show_preferences() -> Result<()> {
+    let preferences = load_preferences()?;
+    let json = serde_json::to_string_pretty(&ShowPreferences::from(preferences))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn set_default_memory(args: SetDefaultMemoryArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences.default_memory_id.as_deref() == Some(memory_id.as_str()) {
+        return print_json_response(PrefsResponse::unchanged(
+            "default_memory_id",
+            "set",
+            Some(memory_id),
+        ));
+    }
+
+    preferences.default_memory_id = Some(memory_id.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "default_memory_id",
+        "set",
+        Some(memory_id),
+    ))
+}
+
+fn clear_default_memory() -> Result<()> {
+    let mut preferences = load_preferences()?;
+    if preferences.default_memory_id.is_none() {
+        return print_json_response(PrefsResponse::unchanged(
+            "default_memory_id",
+            "clear",
+            Option::<String>::None,
+        ));
+    }
+
+    preferences.default_memory_id = None;
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "default_memory_id",
+        "clear",
+        Option::<String>::None,
+    ))
+}
+
+fn add_tag(args: TagArgs) -> Result<()> {
+    let tag = validate_tag(args.tag.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences.saved_tags.iter().any(|saved| saved == &tag) {
+        return print_json_response(PrefsResponse::unchanged("saved_tags", "add", Some(tag)));
+    }
+
+    preferences.saved_tags.push(tag.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("saved_tags", "add", Some(tag)))
+}
+
+fn remove_tag(args: TagArgs) -> Result<()> {
+    let tag = validate_tag(args.tag.as_str())?;
+    let mut preferences = load_preferences()?;
+    let original_len = preferences.saved_tags.len();
+    preferences.saved_tags.retain(|saved| saved != &tag);
+
+    if preferences.saved_tags.len() == original_len {
+        return print_json_response(PrefsResponse::unchanged("saved_tags", "remove", Some(tag)));
+    }
+
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("saved_tags", "remove", Some(tag)))
+}
+
+fn add_memory(args: MemoryIdArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences
+        .manual_memory_ids
+        .iter()
+        .any(|saved| saved == &memory_id)
+    {
+        return print_json_response(PrefsResponse::unchanged(
+            "manual_memory_ids",
+            "add",
+            Some(memory_id),
+        ));
+    }
+
+    preferences.manual_memory_ids.push(memory_id.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "manual_memory_ids",
+        "add",
+        Some(memory_id),
+    ))
+}
+
+fn remove_memory(args: MemoryIdArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    let original_len = preferences.manual_memory_ids.len();
+    preferences
+        .manual_memory_ids
+        .retain(|saved| saved != &memory_id);
+
+    if preferences.manual_memory_ids.len() == original_len {
+        return print_json_response(PrefsResponse::unchanged(
+            "manual_memory_ids",
+            "remove",
+            Some(memory_id),
+        ));
+    }
+
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "manual_memory_ids",
+        "remove",
+        Some(memory_id),
+    ))
+}
+
+fn load_preferences() -> Result<UserPreferences> {
+    preferences::load_user_preferences().context("Failed to load shared TUI preferences")
+}
+
+fn save_preferences(user_preferences: &UserPreferences) -> Result<()> {
+    let normalized = preferences::normalize_user_preferences(user_preferences.clone());
+    preferences::save_user_preferences(&normalized).context("Failed to save shared TUI preferences")
+}
+
+fn validate_memory_id(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("memory id must not be empty");
+    }
+
+    Principal::from_text(trimmed).with_context(|| format!("invalid principal text: {trimmed}"))?;
+    Ok(trimmed.to_string())
+}
+
+fn validate_tag(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("tag must not be empty");
+    }
+
+    Ok(trimmed.to_string())
+}
+
+#[derive(Debug, Serialize)]
+struct ShowPreferences {
+    default_memory_id: Option<String>,
+    saved_tags: Vec<String>,
+    manual_memory_ids: Vec<String>,
+}
+
+impl From<UserPreferences> for ShowPreferences {
+    fn from(value: UserPreferences) -> Self {
+        Self {
+            default_memory_id: value.default_memory_id,
+            saved_tags: value.saved_tags,
+            manual_memory_ids: value.manual_memory_ids,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PrefsResponse<T>
+where
+    T: Serialize,
+{
+    resource: &'static str,
+    action: &'static str,
+    status: &'static str,
+    value: T,
+}
+
+impl<T> PrefsResponse<T>
+where
+    T: Serialize,
+{
+    fn updated(resource: &'static str, action: &'static str, value: T) -> Self {
+        Self {
+            resource,
+            action,
+            status: "updated",
+            value,
+        }
+    }
+
+    fn unchanged(resource: &'static str, action: &'static str, value: T) -> Self {
+        Self {
+            resource,
+            action,
+            status: "unchanged",
+            value,
+        }
+    }
+}
+
+fn print_json_response<T>(response: PrefsResponse<T>) -> Result<()>
+where
+    T: Serialize,
+{
+    let json = serde_json::to_string_pretty(&response)?;
+    println!("{json}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preferences::{
+        DEFAULT_CHAT_MMR_LAMBDA, DEFAULT_CHAT_OVERALL_TOP_K, DEFAULT_CHAT_PER_MEMORY_CAP,
+    };
+
+    #[test]
+    fn validate_memory_id_accepts_principal_text() {
+        let memory_id = validate_memory_id("aaaaa-aa").unwrap();
+        assert_eq!(memory_id, "aaaaa-aa");
+    }
+
+    #[test]
+    fn validate_memory_id_rejects_empty_input() {
+        let error = validate_memory_id("   ").unwrap_err();
+        assert_eq!(error.to_string(), "memory id must not be empty");
+    }
+
+    #[test]
+    fn validate_memory_id_rejects_invalid_principal() {
+        let error = validate_memory_id("not-a-principal").unwrap_err();
+        assert!(error.to_string().contains("invalid principal text"));
+    }
+
+    #[test]
+    fn validate_tag_trims_input() {
+        let tag = validate_tag("  docs  ").unwrap();
+        assert_eq!(tag, "docs");
+    }
+
+    #[test]
+    fn validate_tag_rejects_empty_input() {
+        let error = validate_tag("  ").unwrap_err();
+        assert_eq!(error.to_string(), "tag must not be empty");
+    }
+
+    #[test]
+    fn save_preferences_normalizes_mutated_fields_and_preserves_chat_settings() {
+        let preferences = UserPreferences {
+            default_memory_id: Some("aaaaa-aa".to_string()),
+            saved_tags: vec![" docs ".to_string(), "docs".to_string(), "zeta".to_string()],
+            manual_memory_ids: vec!["bbbbb-bb".to_string(), "bbbbb-bb".to_string()],
+            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
+            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
+            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
+        };
+
+        let normalized = preferences::normalize_user_preferences(preferences);
+
+        assert_eq!(normalized.default_memory_id.as_deref(), Some("aaaaa-aa"));
+        assert_eq!(
+            normalized.saved_tags,
+            vec!["docs".to_string(), "zeta".to_string()]
+        );
+        assert_eq!(normalized.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
+        assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
+        assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
+        assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
+    }
+
+    #[test]
+    fn show_preferences_from_user_preferences_omits_chat_fields() {
+        let serialized = serde_json::to_value(ShowPreferences::from(UserPreferences::default()))
+            .expect("show preferences should serialize");
+
+        assert_eq!(serialized["default_memory_id"], serde_json::Value::Null);
+        assert_eq!(serialized["saved_tags"], serde_json::json!([]));
+        assert_eq!(serialized["manual_memory_ids"], serde_json::json!([]));
+        assert!(serialized.get("chat_overall_top_k").is_none());
+    }
+
+    #[test]
+    fn prefs_response_serializes_with_status_and_value() {
+        let serialized = serde_json::to_value(PrefsResponse::updated(
+            "saved_tags",
+            "add",
+            Some("docs".to_string()),
+        ))
+        .expect("prefs response should serialize");
+
+        assert_eq!(serialized["resource"], "saved_tags");
+        assert_eq!(serialized["action"], "add");
+        assert_eq!(serialized["status"], "updated");
+        assert_eq!(serialized["value"], serde_json::json!("docs"));
+    }
+}

--- a/rust/commands/rename.rs
+++ b/rust/commands/rename.rs
@@ -1,0 +1,50 @@
+//! Memory rename command for the Kinic CLI.
+//! Where: handles `kinic-cli rename`.
+//! What: validates the target and forwards the new name to `change_name`.
+//! Why: expose the existing rename API without requiring the TUI.
+
+use anyhow::{Result, bail};
+use tracing::info;
+
+use crate::{cli::RenameArgs, memory_client_builder::build_memory_client};
+
+use super::CommandContext;
+
+pub async fn handle(args: RenameArgs, ctx: &CommandContext) -> Result<()> {
+    let next_name = validate_name(&args.name)?;
+
+    let client = build_memory_client(&ctx.agent_factory, &args.memory_id).await?;
+    client.change_name(next_name).await?;
+
+    info!(
+        canister_id = %client.canister_id(),
+        name = next_name,
+        "renamed memory canister"
+    );
+
+    println!(
+        "Renamed memory canister {} to {}",
+        client.canister_id(),
+        next_name
+    );
+    Ok(())
+}
+
+fn validate_name(raw: &str) -> Result<&str> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("name must not be empty");
+    }
+    Ok(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_name;
+
+    #[test]
+    fn validate_name_rejects_blank_values() {
+        let error = validate_name("   ").unwrap_err();
+        assert_eq!(error.to_string(), "name must not be empty");
+    }
+}

--- a/rust/commands/search.rs
+++ b/rust/commands/search.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use tokio::{sync::Semaphore, task::JoinSet};
 use tracing::info;
 
@@ -26,38 +27,75 @@ const MAX_CONCURRENT_SEARCHES: usize = 10;
 pub async fn handle(args: SearchArgs, ctx: &CommandContext) -> Result<()> {
     let agent = ctx.agent_factory.build().await?;
     let embedding = fetch_embedding(&args.query).await?;
-    let rows = if args.all {
+    let output = if args.all {
         let target_memory_ids = searchable_memory_ids(agent.clone()).await?;
-        search_across_memories(agent, target_memory_ids, embedding).await?
+        let batch = search_across_memories(agent, target_memory_ids, embedding).await?;
+        SearchOutput {
+            query: args.query.clone(),
+            scope: "all",
+            memory_id: None,
+            searched_memory_ids: batch.searched_memory_ids,
+            result_count: batch.items.len(),
+            failed_memory_ids: batch.failed_memory_ids,
+            items: batch.items,
+        }
     } else {
         let memory_id = args
             .memory_id
             .clone()
             .context("search requires --memory-id unless --all is set")?;
-        search_single_memory(agent, memory_id, embedding).await?
+        let batch = search_single_memory(agent, memory_id.clone(), embedding).await?;
+        SearchOutput {
+            query: args.query.clone(),
+            scope: "selected",
+            memory_id: Some(memory_id),
+            searched_memory_ids: Vec::new(),
+            result_count: batch.items.len(),
+            failed_memory_ids: Vec::new(),
+            items: batch.items,
+        }
     };
 
     info!(
         query = %args.query,
-        result_count = rows.len(),
+        result_count = output.items.len(),
         searched_all = args.all,
         "search completed"
     );
 
-    if rows.is_empty() {
-        println!("No matches found for query \"{}\".", args.query);
-        return Ok(());
-    }
-
-    println!("Search results for \"{}\":", args.query);
-    for row in rows {
-        if args.all {
-            println!("- [{}] [{:.4}] {}", row.memory_id, row.score, row.payload);
-        } else {
-            println!("- [{:.4}] {}", row.score, row.payload);
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_search_text(&args.query, args.all, &output.items);
+        if !output.failed_memory_ids.is_empty() {
+            println!(
+                "Note: {} memory searches failed while collecting results.",
+                output.failed_memory_ids.len()
+            );
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct SearchOutput {
+    query: String,
+    scope: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    searched_memory_ids: Vec<String>,
+    result_count: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    failed_memory_ids: Vec<String>,
+    items: Vec<SearchHit>,
+}
+
+#[derive(Debug, PartialEq)]
+struct SearchBatch {
+    searched_memory_ids: Vec<String>,
+    failed_memory_ids: Vec<String>,
+    items: Vec<SearchHit>,
 }
 
 async fn searchable_memory_ids(agent: ic_agent::Agent) -> Result<Vec<String>> {
@@ -70,6 +108,19 @@ async fn searchable_memory_ids(agent: ic_agent::Agent) -> Result<Vec<String>> {
 }
 
 async fn search_single_memory(
+    agent: ic_agent::Agent,
+    memory_id: String,
+    embedding: Vec<f32>,
+) -> Result<SearchBatch> {
+    let rows = search_single_memory_items(agent, memory_id.clone(), embedding).await?;
+    Ok(SearchBatch {
+        searched_memory_ids: vec![memory_id],
+        failed_memory_ids: Vec::new(),
+        items: rows,
+    })
+}
+
+async fn search_single_memory_items(
     agent: ic_agent::Agent,
     memory_id: String,
     embedding: Vec<f32>,
@@ -94,8 +145,9 @@ async fn search_across_memories(
     agent: ic_agent::Agent,
     memory_ids: Vec<String>,
     embedding: Vec<f32>,
-) -> Result<Vec<SearchHit>> {
+) -> Result<SearchBatch> {
     let target_count = memory_ids.len();
+    let searched_memory_ids = memory_ids.clone();
     let concurrency = usize::min(MAX_CONCURRENT_SEARCHES, memory_ids.len().max(1));
     let semaphore = Arc::new(Semaphore::new(concurrency));
     let mut tasks = JoinSet::new();
@@ -109,7 +161,7 @@ async fn search_across_memories(
                 .acquire_owned()
                 .await
                 .expect("search semaphore should remain open");
-            let result = search_single_memory(agent, memory_id.clone(), embedding).await;
+            let result = search_single_memory_items(agent, memory_id.clone(), embedding).await;
             drop(permit);
             (memory_id, result)
         });
@@ -135,19 +187,82 @@ async fn search_across_memories(
     .map_err(anyhow::Error::msg)?;
 
     sort_search_hits(&mut batch.items);
-    if !batch.failed_memory_ids.is_empty() {
-        println!(
-            "Note: {} memory searches failed while collecting results.",
-            batch.failed_memory_ids.len()
-        );
-    }
-    Ok(batch.items)
+    Ok(SearchBatch {
+        searched_memory_ids,
+        failed_memory_ids: batch.failed_memory_ids,
+        items: batch.items,
+    })
 }
 
 fn build_memory_client(agent: ic_agent::Agent, memory_id: &str) -> Result<MemoryClient> {
     let memory = ic_agent::export::Principal::from_text(memory_id)
         .context("Failed to parse memory canister id")?;
     Ok(MemoryClient::new(agent, memory))
+}
+
+fn print_search_text(query: &str, searched_all: bool, rows: &[SearchHit]) {
+    if rows.is_empty() {
+        println!("No matches found for query \"{}\".", query);
+        return;
+    }
+
+    println!("Search results for \"{}\":", query);
+    for row in rows {
+        let display = SearchTextRow::from_payload(&row.payload);
+        if searched_all {
+            println!(
+                "- [{}] [{:.4}] {}",
+                row.memory_id, row.score, display.summary
+            );
+        } else {
+            println!("- [{:.4}] {}", row.score, display.summary);
+        }
+        if let Some(tag) = display.tag {
+            println!("  tag={tag}");
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SearchTextRow {
+    summary: String,
+    tag: Option<String>,
+}
+
+impl SearchTextRow {
+    fn from_payload(payload: &str) -> Self {
+        let trimmed = payload.trim();
+        let Some(value) = serde_json::from_str::<serde_json::Value>(trimmed).ok() else {
+            return Self {
+                summary: trimmed.to_string(),
+                tag: None,
+            };
+        };
+        let Some(object) = value.as_object() else {
+            return Self {
+                summary: trimmed.to_string(),
+                tag: None,
+            };
+        };
+
+        let sentence = object
+            .get("sentence")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let tag = object
+            .get("tag")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+
+        Self {
+            summary: sentence.unwrap_or_else(|| trimmed.to_string()),
+            tag,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -179,5 +294,41 @@ mod tests {
         assert_eq!(rows[0].memory_id, "aaaaa-aa");
         assert_eq!(rows[1].memory_id, "ccccc-cc");
         assert_eq!(rows[2].memory_id, "bbbbb-bb");
+    }
+
+    #[test]
+    fn search_output_serializes_empty_results_for_json_consumers() {
+        let output = serde_json::to_value(SearchOutput {
+            query: "hello".to_string(),
+            scope: "selected",
+            memory_id: Some("aaaaa-aa".to_string()),
+            searched_memory_ids: Vec::new(),
+            result_count: 0,
+            failed_memory_ids: Vec::new(),
+            items: Vec::new(),
+        })
+        .expect("search output should serialize");
+
+        assert_eq!(output["query"], serde_json::json!("hello"));
+        assert_eq!(output["scope"], serde_json::json!("selected"));
+        assert_eq!(output["result_count"], serde_json::json!(0));
+        assert_eq!(output["items"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn search_text_row_prefers_sentence_and_tag_from_json_payload() {
+        let row =
+            SearchTextRow::from_payload(r##"{"sentence":"# Run tests with output","tag":"docs"}"##);
+
+        assert_eq!(row.summary, "# Run tests with output");
+        assert_eq!(row.tag.as_deref(), Some("docs"));
+    }
+
+    #[test]
+    fn search_text_row_falls_back_to_raw_payload() {
+        let row = SearchTextRow::from_payload("plain text payload");
+
+        assert_eq!(row.summary, "plain text payload");
+        assert_eq!(row.tag, None);
     }
 }

--- a/rust/commands/search.rs
+++ b/rust/commands/search.rs
@@ -1,36 +1,183 @@
-use std::cmp::Ordering;
+//! Search commands for one memory or all searchable memories.
+//! Where: handles `kinic-cli search`.
+//! What: embeds the query once, then searches either a single memory or all searchable memories.
+//! Why: close the feature gap with the TUI while keeping the CLI search surface compact.
 
-use anyhow::Result;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::{sync::Semaphore, task::JoinSet};
 use tracing::info;
 
 use crate::{
-    cli::SearchArgs, embedding::fetch_embedding, memory_client_builder::build_memory_client,
+    cli::SearchArgs,
+    clients::{launcher::LauncherClient, memory::MemoryClient},
+    embedding::fetch_embedding,
+    shared::cross_memory_search::{
+        SearchHit, collect_searchable_memory_ids, fold_search_batches,
+        searchable_memory_id_from_state, sort_search_hits,
+    },
 };
 
 use super::CommandContext;
 
-pub async fn handle(args: SearchArgs, ctx: &CommandContext) -> Result<()> {
-    let client = build_memory_client(&ctx.agent_factory, &args.memory_id).await?;
-    let embedding = fetch_embedding(&args.query).await?;
-    let mut results = client.search(embedding).await?;
+const MAX_CONCURRENT_SEARCHES: usize = 10;
 
-    results.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(Ordering::Equal));
+pub async fn handle(args: SearchArgs, ctx: &CommandContext) -> Result<()> {
+    let agent = ctx.agent_factory.build().await?;
+    let embedding = fetch_embedding(&args.query).await?;
+    let rows = if args.all {
+        let target_memory_ids = searchable_memory_ids(agent.clone()).await?;
+        search_across_memories(agent, target_memory_ids, embedding).await?
+    } else {
+        let memory_id = args
+            .memory_id
+            .clone()
+            .context("search requires --memory-id unless --all is set")?;
+        search_single_memory(agent, memory_id, embedding).await?
+    };
 
     info!(
-        canister_id = %client.canister_id(),
         query = %args.query,
-        result_count = results.len(),
+        result_count = rows.len(),
+        searched_all = args.all,
         "search completed"
     );
 
-    if results.is_empty() {
+    if rows.is_empty() {
         println!("No matches found for query \"{}\".", args.query);
-    } else {
-        println!("Search results for \"{}\":", args.query);
-        for (score, text) in results {
-            println!("- [{score:.4}] {text}");
+        return Ok(());
+    }
+
+    println!("Search results for \"{}\":", args.query);
+    for row in rows {
+        if args.all {
+            println!("- [{}] [{:.4}] {}", row.memory_id, row.score, row.payload);
+        } else {
+            println!("- [{:.4}] {}", row.score, row.payload);
+        }
+    }
+    Ok(())
+}
+
+async fn searchable_memory_ids(agent: ic_agent::Agent) -> Result<Vec<String>> {
+    let states = LauncherClient::new(agent).list_memories().await?;
+    collect_searchable_memory_ids(
+        states.into_iter().map(searchable_memory_id_from_state),
+        "no searchable memories are available",
+    )
+    .map_err(anyhow::Error::msg)
+}
+
+async fn search_single_memory(
+    agent: ic_agent::Agent,
+    memory_id: String,
+    embedding: Vec<f32>,
+) -> Result<Vec<SearchHit>> {
+    let client = build_memory_client(agent, &memory_id)?;
+    let mut rows = client
+        .search(embedding)
+        .await
+        .context("Failed to search memory canister")?
+        .into_iter()
+        .map(|(score, payload)| SearchHit {
+            memory_id: memory_id.clone(),
+            score,
+            payload,
+        })
+        .collect::<Vec<_>>();
+    sort_search_hits(&mut rows);
+    Ok(rows)
+}
+
+async fn search_across_memories(
+    agent: ic_agent::Agent,
+    memory_ids: Vec<String>,
+    embedding: Vec<f32>,
+) -> Result<Vec<SearchHit>> {
+    let target_count = memory_ids.len();
+    let concurrency = usize::min(MAX_CONCURRENT_SEARCHES, memory_ids.len().max(1));
+    let semaphore = Arc::new(Semaphore::new(concurrency));
+    let mut tasks = JoinSet::new();
+
+    for memory_id in memory_ids {
+        let agent = agent.clone();
+        let embedding = embedding.clone();
+        let semaphore = semaphore.clone();
+        tasks.spawn(async move {
+            let permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("search semaphore should remain open");
+            let result = search_single_memory(agent, memory_id.clone(), embedding).await;
+            drop(permit);
+            (memory_id, result)
+        });
+    }
+
+    let mut results = Vec::new();
+    let mut join_errors = Vec::new();
+
+    while let Some(task) = tasks.join_next().await {
+        match task {
+            Ok((memory_id, result)) => results.push((memory_id, result)),
+            Err(error) => join_errors.push(error.to_string()),
         }
     }
 
-    Ok(())
+    let mut batch = fold_search_batches(
+        target_count,
+        results,
+        join_errors,
+        "join-error",
+        "Search failed before any memory returned results.",
+    )
+    .map_err(anyhow::Error::msg)?;
+
+    sort_search_hits(&mut batch.items);
+    if !batch.failed_memory_ids.is_empty() {
+        println!(
+            "Note: {} memory searches failed while collecting results.",
+            batch.failed_memory_ids.len()
+        );
+    }
+    Ok(batch.items)
+}
+
+fn build_memory_client(agent: ic_agent::Agent, memory_id: &str) -> Result<MemoryClient> {
+    let memory = ic_agent::export::Principal::from_text(memory_id)
+        .context("Failed to parse memory canister id")?;
+    Ok(MemoryClient::new(agent, memory))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sort_rows_orders_by_score_desc_then_memory_id() {
+        let mut rows = vec![
+            SearchHit {
+                memory_id: "bbbbb-bb".to_string(),
+                score: 0.2,
+                payload: "beta".to_string(),
+            },
+            SearchHit {
+                memory_id: "aaaaa-aa".to_string(),
+                score: 0.9,
+                payload: "alpha".to_string(),
+            },
+            SearchHit {
+                memory_id: "ccccc-cc".to_string(),
+                score: 0.9,
+                payload: "gamma".to_string(),
+            },
+        ];
+
+        sort_search_hits(&mut rows);
+
+        assert_eq!(rows[0].memory_id, "aaaaa-aa");
+        assert_eq!(rows[1].memory_id, "ccccc-cc");
+        assert_eq!(rows[2].memory_id, "bbbbb-bb");
+    }
 }

--- a/rust/commands/show.rs
+++ b/rust/commands/show.rs
@@ -1,0 +1,67 @@
+//! Memory detail display for the Kinic CLI.
+//! Where: handles `kinic-cli show`.
+//! What: fetches metadata, dimension, and users for one memory canister.
+//! Why: give CLI users the same essential detail visibility already available in the TUI.
+
+use anyhow::{Context, Result};
+use tracing::info;
+
+use crate::{
+    cli::ShowArgs,
+    clients::launcher::LauncherClient,
+    memory_client_builder::build_memory_client,
+    shared::access::{format_role, visible_memory_users},
+};
+
+use super::CommandContext;
+
+pub async fn handle(args: ShowArgs, ctx: &CommandContext) -> Result<()> {
+    let agent = ctx.agent_factory.build().await?;
+    let launcher_id = LauncherClient::new(agent.clone()).launcher_id().to_text();
+    let client = build_memory_client(&ctx.agent_factory, &args.memory_id).await?;
+
+    let metadata = client
+        .get_metadata()
+        .await
+        .context("Failed to fetch metadata from memory canister")?;
+    let dim = client
+        .get_dim()
+        .await
+        .context("Failed to fetch memory dimension")?;
+    let users = client
+        .get_users()
+        .await
+        .context("Failed to fetch users from memory canister")?;
+
+    info!(
+        canister_id = %client.canister_id(),
+        name = %metadata.name,
+        "loaded memory canister details"
+    );
+
+    println!("Memory canister: {}", client.canister_id());
+    println!("Name: {}", metadata.name);
+    println!("Version: {}", metadata.version);
+    println!("Dimension: {dim}");
+    println!(
+        "Owners: {}",
+        if metadata.owners.is_empty() {
+            "(none)".to_string()
+        } else {
+            metadata.owners.join(", ")
+        }
+    );
+    println!("Stable memory size: {}", metadata.stable_memory_size);
+    println!("Cycle amount: {}", metadata.cycle_amount);
+    println!("Users:");
+    let visible_users = visible_memory_users(users, &launcher_id);
+    if visible_users.is_empty() {
+        println!("- (none)");
+    } else {
+        for user in visible_users {
+            println!("- {}: {}", user.principal_id, format_role(user.role_code));
+        }
+    }
+
+    Ok(())
+}

--- a/rust/commands/show.rs
+++ b/rust/commands/show.rs
@@ -4,6 +4,7 @@
 //! Why: give CLI users the same essential detail visibility already available in the TUI.
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use tracing::info;
 
 use crate::{
@@ -39,29 +40,205 @@ pub async fn handle(args: ShowArgs, ctx: &CommandContext) -> Result<()> {
         "loaded memory canister details"
     );
 
-    println!("Memory canister: {}", client.canister_id());
-    println!("Name: {}", metadata.name);
-    println!("Version: {}", metadata.version);
-    println!("Dimension: {dim}");
-    println!(
-        "Owners: {}",
-        if metadata.owners.is_empty() {
-            "(none)".to_string()
-        } else {
-            metadata.owners.join(", ")
-        }
-    );
-    println!("Stable memory size: {}", metadata.stable_memory_size);
-    println!("Cycle amount: {}", metadata.cycle_amount);
-    println!("Users:");
+    let (name, description) = parse_memory_name_fields(&metadata.name);
     let visible_users = visible_memory_users(users, &launcher_id);
-    if visible_users.is_empty() {
-        println!("- (none)");
+    let output = ShowOutput {
+        memory_id: client.canister_id().to_text(),
+        name,
+        description,
+        version: metadata.version,
+        dim,
+        owners: metadata.owners,
+        stable_memory_size: metadata.stable_memory_size,
+        cycle_amount: metadata.cycle_amount,
+        users: visible_users
+            .into_iter()
+            .map(|user| ShowUser {
+                principal_id: user.principal_id,
+                role: format_role(user.role_code),
+            })
+            .collect(),
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
-        for user in visible_users {
-            println!("- {}: {}", user.principal_id, format_role(user.role_code));
-        }
+        print_show_text(&output);
     }
 
     Ok(())
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ShowOutput {
+    memory_id: String,
+    name: String,
+    description: Option<String>,
+    version: String,
+    dim: u64,
+    owners: Vec<String>,
+    stable_memory_size: u32,
+    cycle_amount: u64,
+    users: Vec<ShowUser>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ShowUser {
+    principal_id: String,
+    role: String,
+}
+
+fn print_show_text(output: &ShowOutput) {
+    println!("Memory canister: {}", output.memory_id);
+    println!("Name: {}", output.name);
+    if let Some(description) = &output.description {
+        println!("Description: {description}");
+    }
+    println!("Version: {}", output.version);
+    println!("Dimension: {}", output.dim);
+    println!(
+        "Owners: {}",
+        if output.owners.is_empty() {
+            "(none)".to_string()
+        } else {
+            output.owners.join(", ")
+        }
+    );
+    println!("Stable memory size: {}", output.stable_memory_size);
+    println!("Cycle amount: {}", output.cycle_amount);
+    println!("Users:");
+    if output.users.is_empty() {
+        println!("- (none)");
+    } else {
+        for user in &output.users {
+            println!("- {}: {}", user.principal_id, user.role);
+        }
+    }
+}
+
+fn parse_memory_name_fields(raw: &str) -> (String, Option<String>) {
+    let trimmed = raw.trim();
+    if let Some((name, description)) = parse_detail_object(trimmed) {
+        let normalized_name = name
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| trimmed.to_string());
+        return (normalized_name, description);
+    }
+
+    (trimmed.to_string(), None)
+}
+
+fn parse_detail_object(detail: &str) -> Option<(Option<String>, Option<String>)> {
+    parse_detail_json_object(detail)
+        .or_else(|| parse_detail_jsonish_object(detail))
+        .and_then(|value| {
+            let name = value
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            let description = value
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            (name.is_some() || description.is_some()).then_some((name, description))
+        })
+}
+
+fn parse_detail_json_object(detail: &str) -> Option<serde_json::Value> {
+    let value = serde_json::from_str::<serde_json::Value>(detail).ok()?;
+    value.is_object().then_some(value)
+}
+
+fn parse_detail_jsonish_object(detail: &str) -> Option<serde_json::Value> {
+    let name = extract_jsonish_field(detail, "name");
+    let description = extract_jsonish_field(detail, "description");
+
+    if name.is_none() && description.is_none() {
+        return None;
+    }
+
+    let mut object = serde_json::Map::new();
+    if let Some(name) = name {
+        object.insert("name".to_string(), serde_json::Value::String(name));
+    }
+    if let Some(description) = description {
+        object.insert(
+            "description".to_string(),
+            serde_json::Value::String(description),
+        );
+    }
+    Some(serde_json::Value::Object(object))
+}
+
+fn extract_jsonish_field(detail: &str, key: &str) -> Option<String> {
+    let patterns = [format!("\"{key}\":\""), format!("{key}\":\"")];
+    for pattern in patterns {
+        let Some(found_at) = detail.find(&pattern) else {
+            continue;
+        };
+        let start = found_at + pattern.len();
+        let tail = &detail[start..];
+        let Some(end) = tail.find('"') else {
+            continue;
+        };
+        let value = tail[..end].trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn show_output_serializes_expected_fields() {
+        let output = serde_json::to_value(ShowOutput {
+            memory_id: "aaaaa-aa".to_string(),
+            name: "Alpha".to_string(),
+            description: Some("Quarterly goals".to_string()),
+            version: "1.0.0".to_string(),
+            dim: 8,
+            owners: vec!["owner-a".to_string()],
+            stable_memory_size: 1024,
+            cycle_amount: 2048,
+            users: vec![ShowUser {
+                principal_id: "bbbbb-bb".to_string(),
+                role: "reader".to_string(),
+            }],
+        })
+        .expect("show output should serialize");
+
+        assert_eq!(output["memory_id"], serde_json::json!("aaaaa-aa"));
+        assert_eq!(output["name"], serde_json::json!("Alpha"));
+        assert_eq!(output["description"], serde_json::json!("Quarterly goals"));
+        assert_eq!(output["users"][0]["role"], serde_json::json!("reader"));
+    }
+
+    #[test]
+    fn parse_memory_name_fields_extracts_name_and_description_from_json() {
+        let (name, description) = parse_memory_name_fields(
+            "{\"description\":\"Backend development resources\",\"name\":\"tetetete\"}",
+        );
+
+        assert_eq!(name, "tetetete");
+        assert_eq!(
+            description.as_deref(),
+            Some("Backend development resources")
+        );
+    }
+
+    #[test]
+    fn parse_memory_name_fields_falls_back_to_raw_string() {
+        let (name, description) = parse_memory_name_fields("Alpha Memory");
+
+        assert_eq!(name, "Alpha Memory");
+        assert_eq!(description, None);
+    }
 }

--- a/rust/commands/transfer.rs
+++ b/rust/commands/transfer.rs
@@ -1,0 +1,147 @@
+//! Token transfer command for the Kinic CLI.
+//! Where: handles `kinic-cli transfer`.
+//! What: validates recipient and amount, fetches the current ledger fee, and submits transfer.
+//! Why: expose the same ledger transfer capability the TUI already uses with explicit CLI safety.
+
+use anyhow::{Context, Result, bail};
+use ic_agent::export::Principal;
+use tracing::info;
+
+use crate::{
+    cli::TransferArgs,
+    ledger::{fetch_fee, transfer},
+};
+
+use super::CommandContext;
+
+const E8S_PER_KINIC: u128 = 100_000_000;
+
+pub async fn handle(args: TransferArgs, ctx: &CommandContext) -> Result<()> {
+    if !args.yes {
+        bail!("transfer requires --yes to execute");
+    }
+
+    let recipient = Principal::from_text(args.to.trim())
+        .with_context(|| format!("invalid principal text: {}", args.to.trim()))?;
+    let amount_e8s = parse_kinic_amount_to_e8s(&args.amount)?;
+    let agent = ctx.agent_factory.build().await?;
+    let fee_e8s = fetch_fee(&agent).await?;
+    let block_index = transfer(&agent, recipient, amount_e8s, fee_e8s).await?;
+
+    info!(
+        recipient = %args.to.trim(),
+        amount_e8s,
+        fee_e8s,
+        block_index,
+        "completed kinic transfer"
+    );
+
+    println!("Transfer complete:");
+    println!("Recipient: {}", args.to.trim());
+    println!(
+        "Amount: {} KINIC ({} e8s)",
+        normalize_kinic_display(&args.amount),
+        amount_e8s
+    );
+    println!(
+        "Fee: {:.8} KINIC ({} e8s)",
+        fee_e8s as f64 / E8S_PER_KINIC as f64,
+        fee_e8s
+    );
+    println!("Block index: {block_index}");
+    Ok(())
+}
+
+fn parse_kinic_amount_to_e8s(raw: &str) -> Result<u128> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("amount must not be empty");
+    }
+    if trimmed.starts_with('-') {
+        bail!("amount must be positive");
+    }
+
+    let parts = trimmed.split('.').collect::<Vec<_>>();
+    if parts.len() > 2
+        || parts
+            .iter()
+            .any(|part| !part.chars().all(|ch| ch.is_ascii_digit()))
+    {
+        bail!("amount must be a decimal KINIC value, e.g. 1 or 0.25");
+    }
+
+    let whole = parts[0]
+        .parse::<u128>()
+        .with_context(|| format!("invalid whole amount: {}", parts[0]))?;
+    let fractional_text = if parts.len() == 2 { parts[1] } else { "" };
+    if fractional_text.len() > 8 {
+        bail!("amount supports at most 8 decimal places");
+    }
+
+    let mut fractional = fractional_text.to_string();
+    while fractional.len() < 8 {
+        fractional.push('0');
+    }
+    let fractional_e8s = if fractional.is_empty() {
+        0
+    } else {
+        fractional
+            .parse::<u128>()
+            .with_context(|| format!("invalid fractional amount: {fractional_text}"))?
+    };
+
+    let total = whole
+        .checked_mul(E8S_PER_KINIC)
+        .and_then(|base| base.checked_add(fractional_e8s))
+        .context("amount exceeds supported range")?;
+    if total == 0 {
+        bail!("amount must be greater than zero");
+    }
+    Ok(total)
+}
+
+fn normalize_kinic_display(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if let Some((whole, fraction)) = trimmed.split_once('.') {
+        let normalized_fraction = fraction.trim_end_matches('0');
+        if normalized_fraction.is_empty() {
+            whole.to_string()
+        } else {
+            format!("{whole}.{normalized_fraction}")
+        }
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_kinic_amount_to_e8s_supports_whole_and_fractional_values() {
+        assert_eq!(
+            parse_kinic_amount_to_e8s("1").expect("whole amount"),
+            100_000_000
+        );
+        assert_eq!(
+            parse_kinic_amount_to_e8s("0.25").expect("fractional amount"),
+            25_000_000
+        );
+    }
+
+    #[test]
+    fn parse_kinic_amount_to_e8s_rejects_too_many_decimals() {
+        let error = parse_kinic_amount_to_e8s("0.000000001").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "amount supports at most 8 decimal places"
+        );
+    }
+
+    #[test]
+    fn parse_kinic_amount_to_e8s_rejects_zero() {
+        let error = parse_kinic_amount_to_e8s("0").unwrap_err();
+        assert_eq!(error.to_string(), "amount must be greater than zero");
+    }
+}

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -65,14 +65,12 @@ pub async fn run() -> Result<()> {
 
     match cli.command {
         cli::Command::Capabilities(args) => capabilities::handle(args),
-        cli::Command::Prefs(args) => prefs::handle(args),
+        cli::Command::Prefs(args) => prefs::handle(args, &cli.global).await,
         command => {
             if cli.global.ii
                 && matches!(
                     &command,
-                    cli::Command::Create(_)
-                        | cli::Command::Balance(_)
-                        | cli::Command::Transfer(_)
+                    cli::Command::Create(_) | cli::Command::Balance(_) | cli::Command::Transfer(_)
                 )
                 && !cfg!(feature = "experimental")
             {
@@ -157,7 +155,9 @@ fn validate_keyring_identity(cli: &Cli) -> Result<()> {
     Err(clap_error.into())
 }
 
-fn build_cli_command_context(global: &cli::GlobalOpts) -> Result<(AgentFactory, Option<PathBuf>)> {
+pub(crate) fn build_cli_command_context(
+    global: &cli::GlobalOpts,
+) -> Result<(AgentFactory, Option<PathBuf>)> {
     if global.ii {
         let identity_path = resolve_identity_path(global)?;
         let delegated = identity_store::load_delegated_identity(&identity_path)?;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -57,7 +57,12 @@ pub async fn run() -> Result<()> {
         _ => LevelFilter::TRACE,
     };
 
-    fmt().with_max_level(max).without_time().try_init().ok();
+    fmt()
+        .with_max_level(max)
+        .without_time()
+        .with_writer(std::io::stderr)
+        .try_init()
+        .ok();
 
     if matches!(&cli.command, cli::Command::Tui(_)) {
         return tui::run(&cli.global);

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod insert_service;
 mod ledger;
 pub(crate) mod memory_client_builder;
 mod operation_timeout;
+pub(crate) mod preferences;
 mod prompt_utils;
 #[cfg(feature = "python-bindings")]
 mod python;
@@ -24,7 +25,7 @@ use tracing_subscriber::fmt;
 use crate::{
     agent::AgentFactory,
     cli::Cli,
-    commands::{CommandContext, run_command},
+    commands::{CommandContext, capabilities, prefs, run_command},
 };
 
 pub(crate) const KEYRING_IDENTITY_REQUIRED_MESSAGE: &str =
@@ -61,34 +62,37 @@ pub async fn run() -> Result<()> {
         return tui::run(&cli.global);
     }
 
-    if cli.global.ii
-        && matches!(
-            &cli.command,
-            cli::Command::Create(_) | cli::Command::Balance(_)
-        )
-        && !cfg!(feature = "experimental")
-    {
-        anyhow::bail!(
-            "For security reasons, using a locally hosted origin Internet Identity is not recommended for commands involving asset transfers."
-        );
+    match cli.command {
+        cli::Command::Capabilities(args) => capabilities::handle(args),
+        cli::Command::Prefs(args) => prefs::handle(args),
+        command => {
+            if cli.global.ii
+                && matches!(&command, cli::Command::Create(_) | cli::Command::Balance(_))
+                && !cfg!(feature = "experimental")
+            {
+                anyhow::bail!(
+                    "For security reasons, using a locally hosted origin Internet Identity is not recommended for commands involving asset transfers."
+                );
+            }
+
+            let (agent_factory, identity_path) = if matches!(&command, cli::Command::Login(_)) {
+                let identity_path = Some(resolve_identity_path(&cli.global)?);
+                (
+                    AgentFactory::new(cli.global.ic, String::new()),
+                    identity_path,
+                )
+            } else {
+                build_cli_command_context(&cli.global)?
+            };
+
+            let context = CommandContext {
+                agent_factory,
+                identity_path,
+            };
+
+            run_command(command, context).await
+        }
     }
-
-    let (agent_factory, identity_path) = if matches!(&cli.command, cli::Command::Login(_)) {
-        let identity_path = Some(resolve_identity_path(&cli.global)?);
-        (
-            AgentFactory::new(cli.global.ic, String::new()),
-            identity_path,
-        )
-    } else {
-        build_cli_command_context(&cli.global)?
-    };
-
-    let context = CommandContext {
-        agent_factory,
-        identity_path,
-    };
-
-    run_command(cli.command, context).await
 }
 
 fn validate_tui_cli_args(cli: &Cli) -> Result<()> {
@@ -126,6 +130,12 @@ fn validate_keyring_identity(cli: &Cli) -> Result<()> {
         return Ok(());
     }
     if matches!(&cli.command, cli::Command::Tui(_)) {
+        return Ok(());
+    }
+    if matches!(&cli.command, cli::Command::Capabilities(_)) {
+        return Ok(());
+    }
+    if matches!(&cli.command, cli::Command::Prefs(_)) {
         return Ok(());
     }
     if cli.global.identity.is_some() {
@@ -294,6 +304,32 @@ mod tests {
         let cli = Cli::try_parse_from(["kinic-cli", "--identity", "alice", "tui"]).expect("cli");
 
         validate_keyring_identity(&cli).expect("tui handled by validate_tui_cli_args");
+    }
+
+    #[test]
+    fn validate_keyring_identity_skips_prefs_command_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "prefs", "show"]).expect("cli");
+
+        validate_keyring_identity(&cli).expect("prefs should not require identity");
+    }
+
+    #[test]
+    fn validate_keyring_identity_skips_capabilities_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "capabilities"]).expect("cli");
+
+        validate_keyring_identity(&cli).expect("capabilities should not require identity");
+    }
+
+    #[test]
+    fn cli_parses_prefs_show_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "prefs", "show"]).expect("cli");
+
+        assert!(matches!(
+            cli.command,
+            cli::Command::Prefs(cli::PrefsArgs {
+                command: cli::PrefsCommand::Show
+            })
+        ));
     }
 }
 

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod preferences;
 mod prompt_utils;
 #[cfg(feature = "python-bindings")]
 mod python;
+pub(crate) mod shared;
 pub mod tui;
 
 use anyhow::{Result, anyhow};
@@ -67,7 +68,12 @@ pub async fn run() -> Result<()> {
         cli::Command::Prefs(args) => prefs::handle(args),
         command => {
             if cli.global.ii
-                && matches!(&command, cli::Command::Create(_) | cli::Command::Balance(_))
+                && matches!(
+                    &command,
+                    cli::Command::Create(_)
+                        | cli::Command::Balance(_)
+                        | cli::Command::Transfer(_)
+                )
                 && !cfg!(feature = "experimental")
             {
                 anyhow::bail!(

--- a/rust/preferences.rs
+++ b/rust/preferences.rs
@@ -1,0 +1,216 @@
+//! Shared Kinic preferences persisted for both CLI and TUI.
+//! Where: crate-level module used by CLI prefs commands and the TUI runtime.
+//! What: owns the on-disk schema plus normalization and YAML persistence helpers.
+//! Why: avoid coupling CLI preference management to TUI-specific screen and chat-history code.
+
+use serde::{Deserialize, Serialize};
+use tui_kit_host::settings::SettingsError;
+#[cfg(not(test))]
+use tui_kit_host::settings::{load_yaml_or_default, save_yaml};
+
+#[cfg(not(test))]
+const APP_NAMESPACE: &str = "kinic";
+#[cfg(not(test))]
+const SETTINGS_FILE_NAME: &str = "tui.yaml";
+pub const DEFAULT_CHAT_OVERALL_TOP_K: usize = 8;
+pub const DEFAULT_CHAT_PER_MEMORY_CAP: usize = 3;
+pub const DEFAULT_CHAT_MMR_LAMBDA: u8 = 70;
+const CHAT_RESULT_LIMIT_OPTIONS: &[usize] = &[4, 6, 8, 10, 12];
+const CHAT_PER_MEMORY_LIMIT_OPTIONS: &[usize] = &[1, 2, 3, 4];
+const CHAT_DIVERSITY_OPTIONS: &[u8] = &[60, 70, 80, 90];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// The current on-disk schema is intentionally fixed; unsupported legacy shapes fail to decode.
+pub struct UserPreferences {
+    pub default_memory_id: Option<String>,
+    pub saved_tags: Vec<String>,
+    pub manual_memory_ids: Vec<String>,
+    #[serde(default = "default_chat_overall_top_k")]
+    pub chat_overall_top_k: usize,
+    #[serde(default = "default_chat_per_memory_cap")]
+    pub chat_per_memory_cap: usize,
+    #[serde(default = "default_chat_mmr_lambda")]
+    pub chat_mmr_lambda: u8,
+}
+
+impl Default for UserPreferences {
+    fn default() -> Self {
+        Self {
+            default_memory_id: None,
+            saved_tags: Vec::new(),
+            manual_memory_ids: Vec::new(),
+            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
+            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
+            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
+        }
+    }
+}
+
+pub fn default_chat_overall_top_k() -> usize {
+    DEFAULT_CHAT_OVERALL_TOP_K
+}
+
+pub fn default_chat_per_memory_cap() -> usize {
+    DEFAULT_CHAT_PER_MEMORY_CAP
+}
+
+pub fn default_chat_mmr_lambda() -> u8 {
+    DEFAULT_CHAT_MMR_LAMBDA
+}
+
+#[cfg(test)]
+pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
+    Ok(normalize_user_preferences(UserPreferences::default()))
+}
+
+#[cfg(not(test))]
+pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
+    let preferences: UserPreferences = load_yaml_or_default(APP_NAMESPACE, SETTINGS_FILE_NAME)?;
+    Ok(normalize_user_preferences(preferences))
+}
+
+#[cfg(test)]
+pub fn save_user_preferences(_preferences: &UserPreferences) -> Result<(), SettingsError> {
+    Ok(())
+}
+
+#[cfg(not(test))]
+pub fn save_user_preferences(preferences: &UserPreferences) -> Result<(), SettingsError> {
+    save_yaml(
+        APP_NAMESPACE,
+        SETTINGS_FILE_NAME,
+        &normalize_user_preferences(preferences.clone()),
+    )
+}
+
+pub fn normalize_saved_tags(mut tags: Vec<String>) -> Vec<String> {
+    tags = tags
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+pub fn normalize_user_preferences(mut preferences: UserPreferences) -> UserPreferences {
+    preferences.saved_tags = normalize_saved_tags(preferences.saved_tags);
+    preferences.manual_memory_ids = normalize_manual_memory_ids(preferences.manual_memory_ids);
+    preferences.chat_overall_top_k = normalize_chat_overall_top_k(preferences.chat_overall_top_k);
+    preferences.chat_per_memory_cap =
+        normalize_chat_per_memory_cap(preferences.chat_per_memory_cap);
+    preferences.chat_mmr_lambda = normalize_chat_mmr_lambda(preferences.chat_mmr_lambda);
+    preferences
+}
+
+pub fn normalize_chat_overall_top_k(value: usize) -> usize {
+    if CHAT_RESULT_LIMIT_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_OVERALL_TOP_K
+    }
+}
+
+pub fn normalize_chat_per_memory_cap(value: usize) -> usize {
+    if CHAT_PER_MEMORY_LIMIT_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_PER_MEMORY_CAP
+    }
+}
+
+pub fn normalize_chat_mmr_lambda(value: u8) -> u8 {
+    if CHAT_DIVERSITY_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_MMR_LAMBDA
+    }
+}
+
+pub fn chat_result_limit_options() -> &'static [usize] {
+    CHAT_RESULT_LIMIT_OPTIONS
+}
+
+pub fn chat_per_memory_limit_options() -> &'static [usize] {
+    CHAT_PER_MEMORY_LIMIT_OPTIONS
+}
+
+pub fn chat_diversity_options() -> &'static [u8] {
+    CHAT_DIVERSITY_OPTIONS
+}
+
+pub fn chat_result_limit_display(value: usize) -> String {
+    format!("{value} docs")
+}
+
+pub fn chat_per_memory_limit_display(value: usize) -> String {
+    format!("{value} per memory")
+}
+
+pub fn chat_diversity_display(value: u8) -> String {
+    format!("{:.2}", f32::from(value) / 100.0)
+}
+
+fn normalize_manual_memory_ids(memory_ids: Vec<String>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for memory_id in memory_ids
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        if !unique.iter().any(|existing| existing == &memory_id) {
+            unique.push(memory_id);
+        }
+    }
+    unique
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_preferences_accepts_unknown_fields() {
+        let with_unknown: UserPreferences = serde_yaml::from_str(
+            r#"
+default_memory_id: aaaaa-aa
+saved_tags:
+  - docs
+manual_memory_ids:
+  - bbbbb-bb
+future_setting: true
+"#,
+        )
+        .expect("unknown fields should be ignored");
+
+        assert_eq!(with_unknown.default_memory_id.as_deref(), Some("aaaaa-aa"));
+        assert_eq!(with_unknown.saved_tags, vec!["docs".to_string()]);
+        assert_eq!(with_unknown.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
+    }
+
+    #[test]
+    fn user_preferences_rejects_missing_saved_tags() {
+        let result = serde_yaml::from_str::<UserPreferences>("default_memory_id: aaaaa-aa\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn user_preferences_normalizes_missing_chat_retrieval_fields() {
+        let preferences: UserPreferences = serde_yaml::from_str(
+            r#"
+default_memory_id: aaaaa-aa
+saved_tags:
+  - docs
+manual_memory_ids:
+  - bbbbb-bb
+"#,
+        )
+        .expect("chat retrieval fields should default");
+
+        let normalized = normalize_user_preferences(preferences);
+        assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
+        assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
+        assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
+    }
+}

--- a/rust/shared/access.rs
+++ b/rust/shared/access.rs
@@ -1,0 +1,150 @@
+//! Shared access-control and memory-user helpers.
+//! Where: consumed by CLI command handlers and TUI bridge code.
+//! What: provides role conversion, principal parsing, validation, and user list normalization.
+//! Why: keep access-control rules and user rendering inputs identical across interfaces.
+
+use anyhow::{Context, Result, bail};
+use ic_agent::export::Principal;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryRole {
+    Admin,
+    Writer,
+    Reader,
+}
+
+impl MemoryRole {
+    pub fn from_str(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "admin" => Ok(Self::Admin),
+            "writer" => Ok(Self::Writer),
+            "reader" => Ok(Self::Reader),
+            _ => bail!("role must be one of: admin, writer, reader"),
+        }
+    }
+
+    pub fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Admin),
+            2 => Some(Self::Writer),
+            3 => Some(Self::Reader),
+            _ => None,
+        }
+    }
+
+    pub fn code(self) -> u8 {
+        match self {
+            Self::Admin => 1,
+            Self::Writer => 2,
+            Self::Reader => 3,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::Writer => "writer",
+            Self::Reader => "reader",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleMemoryUser {
+    pub principal_id: String,
+    pub role_code: u8,
+}
+
+pub fn format_role(code: u8) -> String {
+    MemoryRole::from_code(code)
+        .map(|role| role.as_str().to_string())
+        .unwrap_or_else(|| format!("unknown({code})"))
+}
+
+pub fn parse_user_principal(value: &str) -> Result<Principal> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("principal must not be empty");
+    }
+    if trimmed == "anonymous" {
+        return Ok(Principal::anonymous());
+    }
+
+    Principal::from_text(trimmed).with_context(|| format!("invalid principal text: {trimmed}"))
+}
+
+pub fn validate_role_assignment(principal_text: &str, role: MemoryRole) -> Result<()> {
+    if principal_text.trim() == "anonymous" && role == MemoryRole::Admin {
+        bail!("cannot grant admin role to anonymous");
+    }
+    Ok(())
+}
+
+pub fn ensure_not_launcher_principal(principal: &Principal, launcher_id: &str) -> Result<()> {
+    if principal.to_text() == launcher_id {
+        bail!("launcher canister access cannot be modified");
+    }
+    Ok(())
+}
+
+pub fn visible_memory_users(users: Vec<(String, u8)>, launcher_id: &str) -> Vec<VisibleMemoryUser> {
+    let mut visible_users = users
+        .into_iter()
+        .filter(|(principal_id, _)| principal_id != launcher_id)
+        .map(|(principal_id, role_code)| VisibleMemoryUser {
+            principal_id,
+            role_code,
+        })
+        .collect::<Vec<_>>();
+    visible_users.sort_by(|left, right| left.principal_id.cmp(&right.principal_id));
+    visible_users
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_user_principal_supports_anonymous() {
+        assert_eq!(
+            parse_user_principal("anonymous").expect("anonymous principal"),
+            Principal::anonymous()
+        );
+    }
+
+    #[test]
+    fn validate_role_assignment_rejects_anonymous_admin() {
+        let error = validate_role_assignment("anonymous", MemoryRole::Admin).unwrap_err();
+        assert_eq!(error.to_string(), "cannot grant admin role to anonymous");
+    }
+
+    #[test]
+    fn format_role_keeps_unknown_codes_visible() {
+        assert_eq!(format_role(9), "unknown(9)");
+    }
+
+    #[test]
+    fn visible_memory_users_excludes_launcher_and_sorts_rows() {
+        let users = vec![
+            ("zzzzz-zz".to_string(), 3),
+            ("launcher-aa".to_string(), 0),
+            ("aaaaa-aa".to_string(), 1),
+        ];
+
+        let filtered = visible_memory_users(users, "launcher-aa");
+
+        assert_eq!(
+            filtered,
+            vec![
+                VisibleMemoryUser {
+                    principal_id: "aaaaa-aa".to_string(),
+                    role_code: 1,
+                },
+                VisibleMemoryUser {
+                    principal_id: "zzzzz-zz".to_string(),
+                    role_code: 3,
+                },
+            ]
+        );
+    }
+}

--- a/rust/shared/cross_memory_search.rs
+++ b/rust/shared/cross_memory_search.rs
@@ -1,0 +1,184 @@
+//! Shared helpers for cross-memory search target selection and result folding.
+//! Where: reused by CLI search and TUI live-search code.
+//! What: normalizes searchable memory ids, search-hit rows, and partial-failure folding.
+//! Why: keep all-memory search behavior aligned without sharing UI-specific orchestration.
+
+use std::cmp::Ordering;
+
+use crate::clients::launcher::State;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchHit {
+    pub memory_id: String,
+    pub score: f32,
+    pub payload: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FoldedSearchBatch<T> {
+    pub items: Vec<T>,
+    pub failed_memory_ids: Vec<String>,
+}
+
+pub fn searchable_memory_id_from_state(state: State) -> Option<String> {
+    match state {
+        State::Installation(principal, _)
+        | State::SettingUp(principal)
+        | State::Running(principal) => Some(principal.to_text()),
+        _ => None,
+    }
+}
+
+pub fn collect_searchable_memory_ids<I>(ids: I, empty_message: &str) -> Result<Vec<String>, String>
+where
+    I: IntoIterator<Item = Option<String>>,
+{
+    let collected = ids.into_iter().flatten().collect::<Vec<_>>();
+    if collected.is_empty() {
+        Err(empty_message.to_string())
+    } else {
+        Ok(collected)
+    }
+}
+
+pub fn sort_search_hits(rows: &mut [SearchHit]) {
+    rows.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.memory_id.cmp(&right.memory_id))
+            .then_with(|| left.payload.cmp(&right.payload))
+    });
+}
+
+pub fn fold_search_batches<T, E>(
+    target_count: usize,
+    results: Vec<(String, Result<Vec<T>, E>)>,
+    join_errors: Vec<String>,
+    join_error_memory_id: &str,
+    all_failed_message: &str,
+) -> Result<FoldedSearchBatch<T>, String>
+where
+    E: ToString,
+{
+    let mut items = Vec::new();
+    let mut failed_memory_ids = Vec::new();
+    let mut first_error = None;
+
+    for (memory_id, result) in results {
+        match result {
+            Ok(mut next_items) => items.append(&mut next_items),
+            Err(error) => {
+                failed_memory_ids.push(memory_id);
+                if first_error.is_none() {
+                    first_error = Some(error.to_string());
+                }
+            }
+        }
+    }
+
+    for error in join_errors {
+        failed_memory_ids.push(join_error_memory_id.to_string());
+        if first_error.is_none() {
+            first_error = Some(error);
+        }
+    }
+
+    if target_count > 0 && failed_memory_ids.len() == target_count {
+        return Err(first_error.unwrap_or_else(|| all_failed_message.to_string()));
+    }
+
+    Ok(FoldedSearchBatch {
+        items,
+        failed_memory_ids,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::Principal;
+
+    #[test]
+    fn searchable_memory_id_from_state_keeps_searchable_variants_only() {
+        let running = searchable_memory_id_from_state(State::Running(Principal::anonymous()));
+        let empty = searchable_memory_id_from_state(State::Empty("none".to_string()));
+
+        assert_eq!(running.as_deref(), Some("2vxsx-fae"));
+        assert_eq!(empty, None);
+    }
+
+    #[test]
+    fn collect_searchable_memory_ids_rejects_empty_inputs() {
+        let error =
+            collect_searchable_memory_ids(Vec::<Option<String>>::new(), "no memories").unwrap_err();
+        assert_eq!(error, "no memories");
+    }
+
+    #[test]
+    fn sort_search_hits_orders_by_score_desc_then_memory_id() {
+        let mut rows = vec![
+            SearchHit {
+                memory_id: "bbbbb-bb".to_string(),
+                score: 0.2,
+                payload: "beta".to_string(),
+            },
+            SearchHit {
+                memory_id: "aaaaa-aa".to_string(),
+                score: 0.9,
+                payload: "alpha".to_string(),
+            },
+            SearchHit {
+                memory_id: "ccccc-cc".to_string(),
+                score: 0.9,
+                payload: "gamma".to_string(),
+            },
+        ];
+
+        sort_search_hits(&mut rows);
+
+        assert_eq!(rows[0].memory_id, "aaaaa-aa");
+        assert_eq!(rows[1].memory_id, "ccccc-cc");
+        assert_eq!(rows[2].memory_id, "bbbbb-bb");
+    }
+
+    #[test]
+    fn fold_search_batches_keeps_partial_success_and_failed_ids() {
+        let batch = fold_search_batches(
+            2,
+            vec![
+                (
+                    "aaaaa-aa".to_string(),
+                    Ok(vec![SearchHit {
+                        memory_id: "aaaaa-aa".to_string(),
+                        score: 0.5,
+                        payload: "alpha".to_string(),
+                    }]),
+                ),
+                ("bbbbb-bb".to_string(), Err("boom")),
+            ],
+            Vec::new(),
+            "join-error",
+            "all failed",
+        )
+        .expect("partial success should survive");
+
+        assert_eq!(batch.items.len(), 1);
+        assert_eq!(batch.failed_memory_ids, vec!["bbbbb-bb".to_string()]);
+    }
+
+    #[test]
+    fn fold_search_batches_errors_when_everything_fails() {
+        let error = fold_search_batches::<SearchHit, _>(
+            1,
+            vec![("aaaaa-aa".to_string(), Err("boom"))],
+            Vec::new(),
+            "join-error",
+            "all failed",
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "boom");
+    }
+}

--- a/rust/shared/cross_memory_search.rs
+++ b/rust/shared/cross_memory_search.rs
@@ -7,7 +7,7 @@ use std::cmp::Ordering;
 
 use crate::clients::launcher::State;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct SearchHit {
     pub memory_id: String,
     pub score: f32,

--- a/rust/shared/mod.rs
+++ b/rust/shared/mod.rs
@@ -1,0 +1,7 @@
+//! Shared pure logic reused across CLI and TUI.
+//! Where: crate-level internal helpers used by command handlers and TUI bridge/provider code.
+//! What: centralizes memory access/user normalization and cross-memory search batching.
+//! Why: keep behavior aligned across interfaces without coupling the implementations together.
+
+pub mod access;
+pub mod cross_memory_search;

--- a/rust/tui/bridge.rs
+++ b/rust/tui/bridge.rs
@@ -10,6 +10,13 @@ use crate::{
     embedding::embedding_base_url,
     insert_service::{InsertRequest, execute_insert_request},
     ledger::{fetch_balance, fetch_fee, transfer},
+    shared::{
+        access::{
+            MemoryRole, ensure_not_launcher_principal, format_role, parse_user_principal,
+            validate_role_assignment, visible_memory_users,
+        },
+        cross_memory_search::SearchHit,
+    },
     tui::TuiAuth,
     tui::settings::session_settings_snapshot,
 };
@@ -36,12 +43,7 @@ pub struct MemorySummary {
     pub users: Option<Vec<MemoryUser>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct SearchResultItem {
-    pub memory_id: String,
-    pub score: f32,
-    pub payload: String,
-}
+pub type SearchResultItem = SearchHit;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AskMemoriesOutput {
@@ -612,15 +614,6 @@ fn memory_summary_from_state(state: State) -> MemorySummary {
     }
 }
 
-fn role_name(role_code: u8) -> String {
-    match role_code {
-        1 => "admin".to_string(),
-        2 => "writer".to_string(),
-        3 => "reader".to_string(),
-        other => format!("unknown({other})"),
-    }
-}
-
 fn memory_users_from_query(
     users: Result<Vec<(String, u8)>, anyhow::Error>,
     launcher_id: &str,
@@ -632,12 +625,11 @@ fn memory_users_from_query(
 }
 
 fn decode_memory_users(users: Vec<(String, u8)>, launcher_id: &str) -> Vec<MemoryUser> {
-    users
+    visible_memory_users(users, launcher_id)
         .into_iter()
-        .filter(|(principal_id, _)| principal_id != launcher_id)
-        .map(|(principal_id, role_code)| MemoryUser {
-            principal_id,
-            role: role_name(role_code),
+        .map(|user| MemoryUser {
+            principal_id: user.principal_id,
+            role: format_role(user.role_code),
         })
         .collect()
 }
@@ -649,9 +641,7 @@ fn build_access_control_request(
     launcher_id: &str,
 ) -> Result<AccessControlRequest> {
     let principal = parse_access_control_principal(principal_id)?;
-    if principal.to_text() == launcher_id {
-        anyhow::bail!("launcher canister access cannot be modified");
-    }
+    ensure_not_launcher_principal(&principal, launcher_id)?;
     let role_code = match action {
         AccessControlAction::Remove => None,
         AccessControlAction::Add | AccessControlAction::Change => {
@@ -667,22 +657,17 @@ fn build_access_control_request(
 }
 
 fn parse_access_control_principal(principal_id: &str) -> Result<Principal> {
-    if principal_id == "anonymous" {
-        return Ok(Principal::anonymous());
-    }
-    Principal::from_text(principal_id)
-        .with_context(|| format!("invalid principal text: {principal_id}"))
+    parse_user_principal(principal_id)
 }
 
 fn role_code(role: AccessControlRole, principal_id: &str) -> Result<u8> {
-    if role == AccessControlRole::Admin && principal_id == "anonymous" {
-        anyhow::bail!("cannot grant admin role to anonymous");
-    }
-    Ok(match role {
-        AccessControlRole::Admin => 1,
-        AccessControlRole::Writer => 2,
-        AccessControlRole::Reader => 3,
-    })
+    let memory_role = match role {
+        AccessControlRole::Admin => MemoryRole::Admin,
+        AccessControlRole::Writer => MemoryRole::Writer,
+        AccessControlRole::Reader => MemoryRole::Reader,
+    };
+    validate_role_assignment(principal_id, memory_role)?;
+    Ok(memory_role.code())
 }
 
 fn short_error(message: &str) -> String {

--- a/rust/tui/mod.rs
+++ b/rust/tui/mod.rs
@@ -19,7 +19,7 @@ mod chat_retrieval;
 mod chat_service;
 mod chat_similarity;
 mod provider;
-mod settings;
+pub(crate) mod settings;
 mod ui_config;
 
 #[cfg(test)]

--- a/rust/tui/provider/mod.rs
+++ b/rust/tui/provider/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         validate_insert_request_for_submit,
     },
     preferences::{self, UserPreferences},
+    shared::cross_memory_search::{collect_searchable_memory_ids, fold_search_batches},
     tui::TuiAuth,
 };
 use ic_agent::export::Principal;
@@ -224,37 +225,19 @@ fn fold_live_search_results(
     results: Vec<MemorySearchTaskResult>,
     join_errors: Vec<tokio::task::JoinError>,
 ) -> Result<SearchBatchResult, String> {
-    let mut items = Vec::new();
-    let mut failed_memory_ids = Vec::new();
-    let mut first_error = None;
-
-    for (memory_id, result) in results {
-        match result {
-            Ok(mut next_items) => items.append(&mut next_items),
-            Err(error) => {
-                failed_memory_ids.push(memory_id);
-                if first_error.is_none() {
-                    first_error = Some(error.to_string());
-                }
-            }
-        }
-    }
-
-    for error in join_errors {
-        failed_memory_ids.push(SEARCH_JOIN_ERROR_MEMORY_ID.to_string());
-        if first_error.is_none() {
-            first_error = Some(error.to_string());
-        }
-    }
-
-    if target_count > 0 && failed_memory_ids.len() == target_count {
-        return Err(first_error
-            .unwrap_or_else(|| "Search failed before any memory returned results.".to_string()));
-    }
-
+    let folded = fold_search_batches(
+        target_count,
+        results,
+        join_errors
+            .into_iter()
+            .map(|error| error.to_string())
+            .collect(),
+        SEARCH_JOIN_ERROR_MEMORY_ID,
+        "Search failed before any memory returned results.",
+    )?;
     Ok(SearchBatchResult {
-        items,
-        failed_memory_ids,
+        items: folded.items,
+        failed_memory_ids: folded.failed_memory_ids,
     })
 }
 
@@ -3463,18 +3446,12 @@ impl KinicProvider {
 
     fn search_target_memory_ids(&self, scope: SearchScope) -> Result<Vec<String>, String> {
         match scope {
-            SearchScope::All => {
-                let targets = self
-                    .memory_records
+            SearchScope::All => collect_searchable_memory_ids(
+                self.memory_records
                     .iter()
-                    .filter_map(|record| record.searchable_memory_id.clone())
-                    .collect::<Vec<_>>();
-                if targets.is_empty() {
-                    Err("No searchable memories are available yet.".to_string())
-                } else {
-                    Ok(targets)
-                }
-            }
+                    .map(|record| record.searchable_memory_id.clone()),
+                "No searchable memories are available yet.",
+            ),
             SearchScope::Selected => {
                 let active_memory_id = self.cursor_memory_id.as_deref().ok_or_else(|| {
                     "Select a memory in the list before running search.".to_string()

--- a/rust/tui/provider/mod.rs
+++ b/rust/tui/provider/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use super::adapter;
 use super::bridge::{self, MemorySummary, SearchResultItem};
 use super::chat_prompt::ActiveMemoryContext;
-use super::settings::{self, PreferencesHealth, UserPreferences};
+use super::settings::{self, PreferencesHealth};
 use crate::{
     create_domain::derive_create_cost,
     embedding::fetch_embedding,
@@ -18,6 +18,7 @@ use crate::{
         InsertRequest, parse_embedding_json, validate_insert_request_fields,
         validate_insert_request_for_submit,
     },
+    preferences::{self, UserPreferences},
     tui::TuiAuth,
 };
 use ic_agent::export::Principal;
@@ -365,7 +366,7 @@ impl<'a> DefaultMemorySelection<'a> {
 }
 
 fn saved_tag_selection(preferences: &UserPreferences) -> Vec<String> {
-    settings::normalize_saved_tags(preferences.saved_tags.clone())
+    preferences::normalize_saved_tags(preferences.saved_tags.clone())
 }
 
 fn add_action_label_for_context(context: PickerContext) -> Option<&'static str> {
@@ -450,32 +451,32 @@ fn picker_items_for_context(
                 .unwrap_or_default(),
             _ => Vec::new(),
         },
-        PickerContext::ChatResultLimit => settings::chat_result_limit_options()
+        PickerContext::ChatResultLimit => preferences::chat_result_limit_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_result_limit_display(*value),
+                    preferences::chat_result_limit_display(*value),
                     user_preferences.chat_overall_top_k == *value,
                 )
             })
             .collect(),
-        PickerContext::ChatPerMemoryLimit => settings::chat_per_memory_limit_options()
+        PickerContext::ChatPerMemoryLimit => preferences::chat_per_memory_limit_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_per_memory_limit_display(*value),
+                    preferences::chat_per_memory_limit_display(*value),
                     user_preferences.chat_per_memory_cap == *value,
                 )
             })
             .collect(),
-        PickerContext::ChatDiversity => settings::chat_diversity_options()
+        PickerContext::ChatDiversity => preferences::chat_diversity_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_diversity_display(*value),
+                    preferences::chat_diversity_display(*value),
                     user_preferences.chat_mmr_lambda == *value,
                 )
             })
@@ -589,7 +590,7 @@ fn reload_preferences_for_apply(
 
     #[cfg(not(test))]
     {
-        settings::load_user_preferences()
+        preferences::load_user_preferences()
     }
 }
 
@@ -601,7 +602,7 @@ fn save_user_preferences_for_apply(
         return Err(tui_kit_host::settings::SettingsError::NoConfigDir);
     }
 
-    settings::save_user_preferences(preferences)
+    preferences::save_user_preferences(preferences)
 }
 
 #[cfg(test)]
@@ -945,7 +946,7 @@ impl KinicProvider {
         let _settings_io_lock = settings_io_lock()
             .lock()
             .expect("settings io lock should be available");
-        let (user_preferences, preferences_health) = match settings::load_user_preferences() {
+        let (user_preferences, preferences_health) = match preferences::load_user_preferences() {
             Ok(preferences) => (preferences, PreferencesHealth::default()),
             Err(error) => (
                 UserPreferences::default(),
@@ -2391,7 +2392,7 @@ impl KinicProvider {
         let mut updated_preferences = self.user_preferences.clone();
         updated_preferences.saved_tags.push(normalized_tag.clone());
         updated_preferences.saved_tags =
-            settings::normalize_saved_tags(updated_preferences.saved_tags);
+            preferences::normalize_saved_tags(updated_preferences.saved_tags);
 
         #[cfg(test)]
         let _settings_io_lock = settings_io_lock()
@@ -2432,7 +2433,7 @@ impl KinicProvider {
             .saved_tags
             .retain(|saved| saved != &normalized_tag);
         updated_preferences.saved_tags =
-            settings::normalize_saved_tags(updated_preferences.saved_tags);
+            preferences::normalize_saved_tags(updated_preferences.saved_tags);
 
         #[cfg(test)]
         let _settings_io_lock = settings_io_lock()
@@ -2707,7 +2708,7 @@ impl KinicProvider {
         if self.user_preferences.chat_overall_top_k == value {
             return CoreEffect::Notify(format!(
                 "Chat result limit already set to {}",
-                settings::chat_result_limit_display(value)
+                preferences::chat_result_limit_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2715,7 +2716,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Chat result limit set to {}",
-                settings::chat_result_limit_display(value)
+                preferences::chat_result_limit_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Chat result limit save failed: {error}")),
         }
@@ -2725,7 +2726,7 @@ impl KinicProvider {
         if self.user_preferences.chat_per_memory_cap == value {
             return CoreEffect::Notify(format!(
                 "Per-memory limit already set to {}",
-                settings::chat_per_memory_limit_display(value)
+                preferences::chat_per_memory_limit_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2733,7 +2734,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Per-memory limit set to {}",
-                settings::chat_per_memory_limit_display(value)
+                preferences::chat_per_memory_limit_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Per-memory limit save failed: {error}")),
         }
@@ -2743,7 +2744,7 @@ impl KinicProvider {
         if self.user_preferences.chat_mmr_lambda == value {
             return CoreEffect::Notify(format!(
                 "Chat diversity already set to {}",
-                settings::chat_diversity_display(value)
+                preferences::chat_diversity_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2751,7 +2752,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Chat diversity set to {}",
-                settings::chat_diversity_display(value)
+                preferences::chat_diversity_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Chat diversity save failed: {error}")),
         }

--- a/rust/tui/settings.rs
+++ b/rust/tui/settings.rs
@@ -16,51 +16,20 @@ use tui_kit_runtime::{
     format_e8s_to_kinic_string_u128,
 };
 
+use crate::preferences::{
+    UserPreferences, chat_diversity_display, chat_per_memory_limit_display,
+    chat_result_limit_display,
+};
 use crate::tui::TuiAuth;
 
 #[cfg(not(test))]
 const APP_NAMESPACE: &str = "kinic";
-#[cfg(not(test))]
-const SETTINGS_FILE_NAME: &str = "tui.yaml";
 #[cfg(not(test))]
 const CHAT_HISTORY_FILE_NAME: &str = "chat-threads.yaml";
 const UNAVAILABLE: &str = "unavailable";
 const NOT_SET: &str = "not set";
 const CHAT_HISTORY_MAX_MESSAGES: usize = 40;
 const CHAT_MESSAGE_MAX_CONTENT_LEN: usize = 4096;
-pub const DEFAULT_CHAT_OVERALL_TOP_K: usize = 8;
-pub const DEFAULT_CHAT_PER_MEMORY_CAP: usize = 3;
-pub const DEFAULT_CHAT_MMR_LAMBDA: u8 = 70;
-const CHAT_RESULT_LIMIT_OPTIONS: &[usize] = &[4, 6, 8, 10, 12];
-const CHAT_PER_MEMORY_LIMIT_OPTIONS: &[usize] = &[1, 2, 3, 4];
-const CHAT_DIVERSITY_OPTIONS: &[u8] = &[60, 70, 80, 90];
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-// The current on-disk schema is intentionally fixed; unsupported legacy shapes fail to decode.
-pub struct UserPreferences {
-    pub default_memory_id: Option<String>,
-    pub saved_tags: Vec<String>,
-    pub manual_memory_ids: Vec<String>,
-    #[serde(default = "default_chat_overall_top_k")]
-    pub chat_overall_top_k: usize,
-    #[serde(default = "default_chat_per_memory_cap")]
-    pub chat_per_memory_cap: usize,
-    #[serde(default = "default_chat_mmr_lambda")]
-    pub chat_mmr_lambda: u8,
-}
-
-impl Default for UserPreferences {
-    fn default() -> Self {
-        Self {
-            default_memory_id: None,
-            saved_tags: Vec::new(),
-            manual_memory_ids: Vec::new(),
-            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
-            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
-            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PreferencesHealth {
@@ -105,43 +74,6 @@ pub struct StoredChatMessage {
 pub struct ActiveChatThread {
     pub thread_id: String,
     pub messages: Vec<(String, String)>,
-}
-
-pub fn default_chat_overall_top_k() -> usize {
-    DEFAULT_CHAT_OVERALL_TOP_K
-}
-
-pub fn default_chat_per_memory_cap() -> usize {
-    DEFAULT_CHAT_PER_MEMORY_CAP
-}
-
-pub fn default_chat_mmr_lambda() -> u8 {
-    DEFAULT_CHAT_MMR_LAMBDA
-}
-
-#[cfg(test)]
-pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
-    Ok(normalize_user_preferences(UserPreferences::default()))
-}
-
-#[cfg(not(test))]
-pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
-    let preferences: UserPreferences = load_yaml_or_default(APP_NAMESPACE, SETTINGS_FILE_NAME)?;
-    Ok(normalize_user_preferences(preferences))
-}
-
-#[cfg(test)]
-pub fn save_user_preferences(_preferences: &UserPreferences) -> Result<(), SettingsError> {
-    Ok(())
-}
-
-#[cfg(not(test))]
-pub fn save_user_preferences(preferences: &UserPreferences) -> Result<(), SettingsError> {
-    save_yaml(
-        APP_NAMESPACE,
-        SETTINGS_FILE_NAME,
-        &normalize_user_preferences(preferences.clone()),
-    )
 }
 
 pub fn current_chat_saved_at() -> u64 {
@@ -779,96 +711,12 @@ fn preferences_status_label(health: &PreferencesHealth) -> String {
     }
 }
 
-pub(crate) fn normalize_saved_tags(mut tags: Vec<String>) -> Vec<String> {
-    tags = tags
-        .into_iter()
-        .map(|tag| tag.trim().to_string())
-        .filter(|tag| !tag.is_empty())
-        .collect();
-    tags.sort();
-    tags.dedup();
-    tags
-}
-
-pub fn normalize_user_preferences(mut preferences: UserPreferences) -> UserPreferences {
-    preferences.saved_tags = normalize_saved_tags(preferences.saved_tags);
-    preferences.manual_memory_ids = normalize_manual_memory_ids(preferences.manual_memory_ids);
-    preferences.chat_overall_top_k = normalize_chat_overall_top_k(preferences.chat_overall_top_k);
-    preferences.chat_per_memory_cap =
-        normalize_chat_per_memory_cap(preferences.chat_per_memory_cap);
-    preferences.chat_mmr_lambda = normalize_chat_mmr_lambda(preferences.chat_mmr_lambda);
-    preferences
-}
-
-pub fn normalize_chat_overall_top_k(value: usize) -> usize {
-    if CHAT_RESULT_LIMIT_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_OVERALL_TOP_K
-    }
-}
-
-pub fn normalize_chat_per_memory_cap(value: usize) -> usize {
-    if CHAT_PER_MEMORY_LIMIT_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_PER_MEMORY_CAP
-    }
-}
-
-pub fn normalize_chat_mmr_lambda(value: u8) -> u8 {
-    if CHAT_DIVERSITY_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_MMR_LAMBDA
-    }
-}
-
-pub fn chat_result_limit_options() -> &'static [usize] {
-    CHAT_RESULT_LIMIT_OPTIONS
-}
-
-pub fn chat_per_memory_limit_options() -> &'static [usize] {
-    CHAT_PER_MEMORY_LIMIT_OPTIONS
-}
-
-pub fn chat_diversity_options() -> &'static [u8] {
-    CHAT_DIVERSITY_OPTIONS
-}
-
-pub fn chat_result_limit_display(value: usize) -> String {
-    format!("{value} docs")
-}
-
-pub fn chat_per_memory_limit_display(value: usize) -> String {
-    format!("{value} per memory")
-}
-
-pub fn chat_diversity_display(value: u8) -> String {
-    format!("{:.2}", f32::from(value) / 100.0)
-}
-
 fn saved_tags_display(preferences: &UserPreferences) -> String {
     if preferences.saved_tags.is_empty() {
         return NOT_SET.to_string();
     }
 
     preferences.saved_tags.join(", ")
-}
-
-#[cfg_attr(test, allow(dead_code))]
-fn normalize_manual_memory_ids(memory_ids: Vec<String>) -> Vec<String> {
-    let mut unique = Vec::new();
-    for memory_id in memory_ids
-        .into_iter()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-    {
-        if !unique.iter().any(|existing| existing == &memory_id) {
-            unique.push(memory_id);
-        }
-    }
-    unique
 }
 
 #[cfg(test)]

--- a/rust/tui/settings_tests.rs
+++ b/rust/tui/settings_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::preferences::UserPreferences;
 use candid::Nat;
 use tui_kit_runtime::{SETTINGS_ENTRY_DEFAULT_MEMORY_ID, SessionAccountOverview};
 
@@ -52,32 +53,6 @@ fn section_entry_value<'a>(snapshot: &'a SettingsSnapshot, section: &str, id: &s
         .and_then(|current| current.entries.iter().find(|entry| entry.id == id))
         .map(|entry| entry.value.as_str())
         .expect("section entry should exist")
-}
-
-#[test]
-fn user_preferences_accepts_unknown_fields() {
-    let with_unknown: UserPreferences = serde_yaml::from_str(
-        r#"
-default_memory_id: aaaaa-aa
-saved_tags:
-  - docs
-manual_memory_ids:
-  - bbbbb-bb
-future_setting: true
-"#,
-    )
-    .expect("unknown fields should be ignored");
-
-    assert_eq!(with_unknown.default_memory_id.as_deref(), Some("aaaaa-aa"));
-    assert_eq!(with_unknown.saved_tags, vec!["docs".to_string()]);
-    assert_eq!(with_unknown.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
-}
-
-#[test]
-fn user_preferences_rejects_missing_saved_tags() {
-    let result = serde_yaml::from_str::<UserPreferences>("default_memory_id: aaaaa-aa\n");
-
-    assert!(result.is_err());
 }
 
 #[test]
@@ -234,26 +209,6 @@ fn settings_snapshot_projects_default_memory_and_preferences_status() {
             "{name}"
         );
     }
-}
-
-#[test]
-fn user_preferences_normalizes_missing_chat_retrieval_fields() {
-    let preferences: UserPreferences = serde_yaml::from_str(
-        r#"
-default_memory_id: aaaaa-aa
-saved_tags:
-  - docs
-manual_memory_ids:
-  - bbbbb-bb
-"#,
-    )
-    .expect("chat retrieval fields should default");
-
-    let normalized = normalize_user_preferences(preferences);
-
-    assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
-    assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
-    assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
 }
 
 #[test]

--- a/skills/kinic-cli-user/SKILL.md
+++ b/skills/kinic-cli-user/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: kinic-cli-user
+description: Explain day-to-day kinic-cli usage for memory canister workflows, including auth mode selection, list/show/search, prefs, config users, and agent-friendly JSON usage. Use when a user asks how to operate the CLI, which command to run, how to inspect or search memories, how to manage prefs, or how to consume kinic-cli from an AI agent or script.
+---
+
+# Kinic CLI User
+
+## Overview
+
+Guide users toward the smallest command that solves the task. Prefer stable read commands first, then mutating commands only when the user is clearly changing state.
+
+Read [`docs/cli.md`](../../docs/cli.md) when you need the full command catalog or complete examples. Use this skill as the short public entrypoint, not the exhaustive reference.
+
+## Workflow
+
+1. Pick the auth mode first.
+2. Identify whether the task is read-only, local-preference, or state-changing.
+3. Prefer `list`, `show`, and `search` for discovery.
+4. Prefer `--json` when the caller is an agent or script.
+5. Keep summarization in the caller when possible; use CLI retrieval as the evidence source.
+
+## Auth Modes
+
+- Use `--identity <name>` for normal CLI operation.
+- Use `--ii` only when the user explicitly wants Internet Identity login.
+- Remember that `prefs` commands that only touch local settings do not require auth.
+- Remember that `prefs add-memory --validate` does require `--identity` or `--ii`.
+
+## Quick Tasks
+
+### Discover memories
+
+Use:
+
+```bash
+cargo run -- --identity alice list
+```
+
+For agents or scripts:
+
+```bash
+cargo run -- --identity alice list --json
+```
+
+`list --json` returns `count` and `items[]` with `memory_id` and launcher `status`.
+
+### Inspect one memory
+
+Use:
+
+```bash
+cargo run -- --identity alice show --memory-id <memory_id>
+```
+
+For agents or scripts:
+
+```bash
+cargo run -- --identity alice show --memory-id <memory_id> --json
+```
+
+`show --json` returns normalized `name`, optional `description`, metadata, owners, cycle amount, stable memory size, and `users[]`.
+
+### Search one memory
+
+Use:
+
+```bash
+cargo run -- --identity alice search --memory-id <memory_id> --query "hello"
+```
+
+For agents or scripts:
+
+```bash
+cargo run -- --identity alice search --memory-id <memory_id> --query "hello" --json
+```
+
+In text mode, prefer the extracted sentence/tag presentation. In JSON mode, consume `items[]` with `score`, `payload`, and `memory_id`.
+
+### Search across all memories
+
+Use:
+
+```bash
+cargo run -- --identity alice search --all --query "hello"
+```
+
+For agents or scripts:
+
+```bash
+cargo run -- --identity alice search --all --query "hello" --json
+```
+
+When `--all` is used with `--json`, expect `searched_memory_ids[]` and possibly `failed_memory_ids[]`.
+
+### Manage prefs
+
+Show current prefs:
+
+```bash
+cargo run -- prefs show
+```
+
+Update retrieval tuning:
+
+```bash
+cargo run -- prefs set-chat-overall-top-k --value 10
+cargo run -- prefs set-chat-per-memory-cap --value 4
+cargo run -- prefs set-chat-mmr-lambda --value 80
+```
+
+Add a manual memory with validation:
+
+```bash
+cargo run -- --identity alice prefs add-memory --memory-id <memory_id> --validate
+```
+
+Treat all `prefs` output as JSON.
+
+### Manage users
+
+List users:
+
+```bash
+cargo run -- --identity alice config users list --memory-id <memory_id>
+```
+
+Add or change a role:
+
+```bash
+cargo run -- --identity alice config users add --memory-id <memory_id> --principal <principal|anonymous> --role <admin|writer|reader>
+cargo run -- --identity alice config users change --memory-id <memory_id> --principal <principal|anonymous> --role <admin|writer|reader>
+```
+
+Remove a role:
+
+```bash
+cargo run -- --identity alice config users remove --memory-id <memory_id> --principal <principal|anonymous>
+```
+
+Remember that `anonymous` cannot be granted `admin`.
+
+## Agent Guidance
+
+- Start with `cargo run -- capabilities` when an agent needs machine-readable command discovery.
+- Prefer this read path:
+  1. `list --json`
+  2. `show --json`
+  3. `search --json`
+- Use `search --all --json` when the task spans multiple memories, and handle optional `failed_memory_ids[]`.
+- Summarize in the agent, not in the CLI.
+- Keep `ask-ai` as a convenience path, not the default integration path.
+
+## Safety Notes
+
+- Treat `transfer` as a state-changing operation that requires explicit confirmation with `--yes`.
+- Treat `rename`, `config users *`, `update`, and `prefs` mutations as write operations.
+- Do not recommend `--ii` casually for flows that are better served by normal `--identity`.
+
+## Boundaries
+
+- Do not invent command flags that are not in `docs/cli.md` or `capabilities`.
+- Do not parse human text output when `--json` is available and the caller is a machine.
+- Do not rely on `ask-ai` when the task only needs retrieval evidence.

--- a/skills/kinic-cli-user/agents/openai.yaml
+++ b/skills/kinic-cli-user/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kinic CLI User"
+  short_description: "Guide day-to-day kinic-cli usage and JSON-oriented workflows."
+  default_prompt: "Use $kinic-cli-user to explain the right kinic-cli command, auth mode, and JSON output path for the user's task."

--- a/tests/kinic_cli_capabilities.rs
+++ b/tests/kinic_cli_capabilities.rs
@@ -38,6 +38,7 @@ fn capabilities_describes_prefs_and_tui_contracts() {
         .expect("prefs command should be present");
     assert_eq!(prefs["requires_auth"], false);
     assert_eq!(prefs["output_mode"], "json");
+    assert_eq!(prefs["supported_output_modes"], json!(["json"]));
     assert!(prefs["subcommands"].is_array());
     assert!(
         prefs["subcommands"]
@@ -60,6 +61,7 @@ fn capabilities_describes_prefs_and_tui_contracts() {
         .expect("tui command should be present");
     assert_eq!(tui["interactive"], true);
     assert_eq!(tui["output_mode"], "interactive");
+    assert_eq!(tui["supported_output_modes"], json!(["interactive"]));
     assert_eq!(tui["auth_modes"], json!(["identity"]));
 }
 
@@ -85,8 +87,36 @@ fn capabilities_describes_major_arguments_for_network_commands() {
         json!([
             { "name": "memory_id", "required": false, "kind": "principal" },
             { "name": "all", "required": false, "kind": "boolean" },
-            { "name": "query", "required": true, "kind": "string" }
+            { "name": "query", "required": true, "kind": "string" },
+            { "name": "json", "required": false, "kind": "boolean" }
         ])
+    );
+    assert_eq!(search["supported_output_modes"], json!(["text", "json"]));
+
+    let list = commands
+        .iter()
+        .find(|entry| entry["name"] == "list")
+        .expect("list command should be present");
+    assert_eq!(list["supported_output_modes"], json!(["text", "json"]));
+    assert!(
+        list["arguments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry == &json!({"name":"json","required":false,"kind":"boolean"}))
+    );
+
+    let show = commands
+        .iter()
+        .find(|entry| entry["name"] == "show")
+        .expect("show command should be present");
+    assert_eq!(show["supported_output_modes"], json!(["text", "json"]));
+    assert!(
+        show["arguments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry == &json!({"name":"json","required":false,"kind":"boolean"}))
     );
     assert_eq!(
         search["arg_groups"],
@@ -122,6 +152,7 @@ fn capabilities_describes_major_arguments_for_network_commands() {
         .expect("capabilities command should be present");
     assert_eq!(capabilities["requires_auth"], false);
     assert_eq!(capabilities["output_mode"], "json");
+    assert_eq!(capabilities["supported_output_modes"], json!(["json"]));
 }
 
 #[test]

--- a/tests/kinic_cli_capabilities.rs
+++ b/tests/kinic_cli_capabilities.rs
@@ -76,8 +76,20 @@ fn capabilities_describes_major_arguments_for_network_commands() {
     assert_eq!(
         search["arguments"],
         json!([
-            { "name": "memory_id", "required": true, "kind": "principal" },
+            { "name": "memory_id", "required": false, "kind": "principal" },
+            { "name": "all", "required": false, "kind": "boolean" },
             { "name": "query", "required": true, "kind": "string" }
+        ])
+    );
+    assert_eq!(
+        search["arg_groups"],
+        json!([
+            {
+                "id": "search_target",
+                "required": true,
+                "multiple": false,
+                "members": ["memory_id", "all"]
+            }
         ])
     );
 
@@ -158,6 +170,54 @@ fn capabilities_prefs_subcommands_match_clap_definition() {
         .find(|command| command.get_name() == "prefs")
         .expect("prefs should exist in clap");
     let clap_names: Vec<String> = clap_prefs
+        .get_subcommands()
+        .map(|command| command.get_name().to_string())
+        .collect();
+
+    assert_eq!(
+        capability_names,
+        clap_names.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn capabilities_config_users_subcommands_match_clap_definition() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+    let config = commands
+        .iter()
+        .find(|entry| entry["name"] == "config")
+        .expect("config command should be present");
+    let users = config["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == "users")
+        .expect("config users should be present");
+    let capability_names: Vec<&str> = users["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+
+    let clap = Cli::command();
+    let clap_config = clap
+        .get_subcommands()
+        .find(|command| command.get_name() == "config")
+        .expect("config should exist in clap");
+    let clap_users = clap_config
+        .get_subcommands()
+        .find(|command| command.get_name() == "users")
+        .expect("config users should exist in clap");
+    let clap_names: Vec<String> = clap_users
         .get_subcommands()
         .map(|command| command.get_name().to_string())
         .collect();

--- a/tests/kinic_cli_capabilities.rs
+++ b/tests/kinic_cli_capabilities.rs
@@ -46,6 +46,13 @@ fn capabilities_describes_prefs_and_tui_contracts() {
             .iter()
             .any(|entry| entry["name"] == "set-default-memory")
     );
+    assert!(
+        prefs["subcommands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["name"] == "set-chat-overall-top-k")
+    );
 
     let tui = commands
         .iter()

--- a/tests/kinic_cli_capabilities.rs
+++ b/tests/kinic_cli_capabilities.rs
@@ -1,0 +1,169 @@
+use std::process::Command;
+
+use _lib::cli::Cli;
+use clap::CommandFactory;
+use serde_json::json;
+
+#[test]
+fn capabilities_runs_without_identity_and_returns_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(parsed["cli"], "kinic-cli");
+    assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+    assert!(parsed["commands"].is_array());
+}
+
+#[test]
+fn capabilities_describes_prefs_and_tui_contracts() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+
+    let prefs = commands
+        .iter()
+        .find(|entry| entry["name"] == "prefs")
+        .expect("prefs command should be present");
+    assert_eq!(prefs["requires_auth"], false);
+    assert_eq!(prefs["output_mode"], "json");
+    assert!(prefs["subcommands"].is_array());
+    assert!(
+        prefs["subcommands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["name"] == "set-default-memory")
+    );
+
+    let tui = commands
+        .iter()
+        .find(|entry| entry["name"] == "tui")
+        .expect("tui command should be present");
+    assert_eq!(tui["interactive"], true);
+    assert_eq!(tui["output_mode"], "interactive");
+    assert_eq!(tui["auth_modes"], json!(["identity"]));
+}
+
+#[test]
+fn capabilities_describes_major_arguments_for_network_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+
+    let search = commands
+        .iter()
+        .find(|entry| entry["name"] == "search")
+        .expect("search command should be present");
+    assert_eq!(search["auth_modes"], json!(["identity", "ii"]));
+    assert_eq!(
+        search["arguments"],
+        json!([
+            { "name": "memory_id", "required": true, "kind": "principal" },
+            { "name": "query", "required": true, "kind": "string" }
+        ])
+    );
+
+    let insert = commands
+        .iter()
+        .find(|entry| entry["name"] == "insert")
+        .expect("insert command should be present");
+    assert_eq!(
+        insert["arg_groups"],
+        json!([
+            {
+                "id": "insert_input",
+                "required": true,
+                "multiple": false,
+                "members": ["text", "file_path"]
+            }
+        ])
+    );
+
+    let capabilities = commands
+        .iter()
+        .find(|entry| entry["name"] == "capabilities")
+        .expect("capabilities command should be present");
+    assert_eq!(capabilities["requires_auth"], false);
+    assert_eq!(capabilities["output_mode"], "json");
+}
+
+#[test]
+fn capabilities_command_names_match_clap_definition() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+    let capability_names: Vec<&str> = commands
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    let clap_names: Vec<String> = Cli::command()
+        .get_subcommands()
+        .map(|command| command.get_name().to_string())
+        .collect();
+
+    assert_eq!(
+        capability_names,
+        clap_names.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn capabilities_prefs_subcommands_match_clap_definition() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+    let prefs = commands
+        .iter()
+        .find(|entry| entry["name"] == "prefs")
+        .expect("prefs command should be present");
+    let capability_names: Vec<&str> = prefs["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    let clap = Cli::command();
+    let clap_prefs = clap
+        .get_subcommands()
+        .find(|command| command.get_name() == "prefs")
+        .expect("prefs should exist in clap");
+    let clap_names: Vec<String> = clap_prefs
+        .get_subcommands()
+        .map(|command| command.get_name().to_string())
+        .collect();
+
+    assert_eq!(
+        capability_names,
+        clap_names.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}

--- a/tests/kinic_cli_commands.rs
+++ b/tests/kinic_cli_commands.rs
@@ -1,0 +1,88 @@
+use _lib::cli::{Cli, Command, ConfigCommand, ConfigUsersCommand};
+use clap::Parser;
+
+#[test]
+fn search_requires_exactly_one_target_selector() {
+    let missing = Cli::try_parse_from(["kinic-cli", "search", "--query", "hello"]);
+    assert!(missing.is_err());
+
+    let conflicting = Cli::try_parse_from([
+        "kinic-cli",
+        "search",
+        "--memory-id",
+        "aaaaa-aa",
+        "--all",
+        "--query",
+        "hello",
+    ]);
+    assert!(conflicting.is_err());
+}
+
+#[test]
+fn search_accepts_all_scope() {
+    let cli = Cli::try_parse_from(["kinic-cli", "search", "--all", "--query", "hello"])
+        .expect("search --all should parse");
+
+    match cli.command {
+        Command::Search(args) => {
+            assert!(args.all);
+            assert_eq!(args.memory_id, None);
+            assert_eq!(args.query, "hello");
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn config_users_subcommands_parse() {
+    let cli = Cli::try_parse_from([
+        "kinic-cli",
+        "config",
+        "users",
+        "change",
+        "--memory-id",
+        "aaaaa-aa",
+        "--principal",
+        "anonymous",
+        "--role",
+        "reader",
+    ])
+    .expect("config users change should parse");
+
+    match cli.command {
+        Command::Config(args) => match args.command {
+            ConfigCommand::Users(users) => match users.command {
+                ConfigUsersCommand::Change(change) => {
+                    assert_eq!(change.memory_id, "aaaaa-aa");
+                    assert_eq!(change.principal, "anonymous");
+                    assert_eq!(change.role, "reader");
+                }
+                other => panic!("unexpected users subcommand: {other:?}"),
+            },
+        },
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn transfer_requires_explicit_yes_flag_to_parse_as_true() {
+    let cli = Cli::try_parse_from([
+        "kinic-cli",
+        "transfer",
+        "--to",
+        "aaaaa-aa",
+        "--amount",
+        "1.25",
+        "--yes",
+    ])
+    .expect("transfer should parse");
+
+    match cli.command {
+        Command::Transfer(args) => {
+            assert_eq!(args.to, "aaaaa-aa");
+            assert_eq!(args.amount, "1.25");
+            assert!(args.yes);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}

--- a/tests/kinic_cli_commands.rs
+++ b/tests/kinic_cli_commands.rs
@@ -86,3 +86,33 @@ fn transfer_requires_explicit_yes_flag_to_parse_as_true() {
         other => panic!("unexpected command: {other:?}"),
     }
 }
+
+#[test]
+fn read_commands_accept_json_flag() {
+    let list = Cli::try_parse_from(["kinic-cli", "list", "--json"]).expect("list should parse");
+    let show = Cli::try_parse_from(["kinic-cli", "show", "--memory-id", "aaaaa-aa", "--json"])
+        .expect("show should parse");
+    let search = Cli::try_parse_from([
+        "kinic-cli",
+        "search",
+        "--memory-id",
+        "aaaaa-aa",
+        "--query",
+        "hello",
+        "--json",
+    ])
+    .expect("search should parse");
+
+    match list.command {
+        Command::List(args) => assert!(args.json),
+        other => panic!("unexpected command: {other:?}"),
+    }
+    match show.command {
+        Command::Show(args) => assert!(args.json),
+        other => panic!("unexpected command: {other:?}"),
+    }
+    match search.command {
+        Command::Search(args) => assert!(args.json),
+        other => panic!("unexpected command: {other:?}"),
+    }
+}

--- a/tests/kinic_cli_prefs.rs
+++ b/tests/kinic_cli_prefs.rs
@@ -55,6 +55,9 @@ fn prefs_show_runs_without_identity() {
             "default_memory_id": null,
             "saved_tags": [],
             "manual_memory_ids": [],
+            "chat_overall_top_k": 8,
+            "chat_per_memory_cap": 3,
+            "chat_mmr_lambda": 70,
         })
     );
 }
@@ -160,6 +163,9 @@ fn prefs_mutations_update_shared_yaml_and_preserve_chat_fields() {
                 "yta6k-5x777-77774-aaaaa-cai",
                 "ryjl3-tyaaa-aaaaa-aaaba-cai"
             ],
+            "chat_overall_top_k": 10,
+            "chat_per_memory_cap": 4,
+            "chat_mmr_lambda": 80,
         })
     );
 }
@@ -241,4 +247,74 @@ fn prefs_clear_default_memory_updates_yaml() {
     assert!(!yaml.contains("default_memory_id: aaaaa-aa"));
     assert!(yaml.contains("saved_tags: []"));
     assert!(yaml.contains("manual_memory_ids: []"));
+}
+
+#[test]
+fn prefs_chat_retrieval_mutations_update_yaml_and_show_output() {
+    let config_dir = temp_config_dir("chat-retrieval");
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "set-chat-overall-top-k", "--value", "10"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("json response should parse");
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "chat_overall_top_k",
+            "action": "set",
+            "status": "updated",
+            "value": 10
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "set-chat-per-memory-cap", "--value", "4"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "set-chat-mmr-lambda", "--value", "80"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let yaml = read_prefs_yaml(&config_dir);
+    assert!(yaml.contains("chat_overall_top_k: 10"));
+    assert!(yaml.contains("chat_per_memory_cap: 4"));
+    assert!(yaml.contains("chat_mmr_lambda: 80"));
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "show"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("show output should parse");
+    assert_eq!(parsed["chat_overall_top_k"], json!(10));
+    assert_eq!(parsed["chat_per_memory_cap"], json!(4));
+    assert_eq!(parsed["chat_mmr_lambda"], json!(80));
+}
+
+#[test]
+fn prefs_add_memory_validate_requires_identity_or_ii() {
+    let config_dir = temp_config_dir("add-memory-validate");
+
+    let output = prefs_command(&config_dir)
+        .args([
+            "prefs",
+            "add-memory",
+            "--memory-id",
+            "ryjl3-tyaaa-aaaaa-aaaba-cai",
+            "--validate",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("--identity is required unless --ii is set"));
 }

--- a/tests/kinic_cli_prefs.rs
+++ b/tests/kinic_cli_prefs.rs
@@ -1,0 +1,244 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::json;
+
+fn temp_config_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kinic-cli-prefs-{name}-{nanos}"));
+    fs::create_dir_all(&path).expect("temp config dir should be created");
+    path
+}
+
+fn app_config_root(home_dir: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home_dir.join("Library").join("Application Support")
+    } else {
+        home_dir.join(".config")
+    }
+}
+
+fn prefs_command(config_dir: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kinic-cli"));
+    command.env("HOME", config_dir);
+    command.env("XDG_CONFIG_HOME", app_config_root(config_dir));
+    command
+}
+
+fn read_prefs_yaml(config_dir: &Path) -> String {
+    fs::read_to_string(app_config_root(config_dir).join("kinic").join("tui.yaml"))
+        .expect("prefs yaml should exist after mutation")
+}
+
+#[test]
+fn prefs_show_runs_without_identity() {
+    let config_dir = temp_config_dir("show");
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "show"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "default_memory_id": null,
+            "saved_tags": [],
+            "manual_memory_ids": [],
+        })
+    );
+}
+
+#[test]
+fn prefs_mutations_update_shared_yaml_and_preserve_chat_fields() {
+    let config_dir = temp_config_dir("mutations");
+    let kinic_dir = app_config_root(&config_dir).join("kinic");
+    fs::create_dir_all(&kinic_dir).unwrap();
+    fs::write(
+        kinic_dir.join("tui.yaml"),
+        concat!(
+            "default_memory_id: yta6k-5x777-77774-aaaaa-cai\n",
+            "saved_tags:\n",
+            "  - keep\n",
+            "manual_memory_ids:\n",
+            "  - yta6k-5x777-77774-aaaaa-cai\n",
+            "chat_overall_top_k: 10\n",
+            "chat_per_memory_cap: 4\n",
+            "chat_mmr_lambda: 80\n"
+        ),
+    )
+    .unwrap();
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "set-default-memory", "--memory-id", "aaaaa-aa"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "default_memory_id",
+            "action": "set",
+            "status": "updated",
+            "value": "aaaaa-aa"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "add-tag", "--tag", "  docs  "])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "saved_tags",
+            "action": "add",
+            "status": "updated",
+            "value": "docs"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args([
+            "prefs",
+            "add-memory",
+            "--memory-id",
+            "ryjl3-tyaaa-aaaaa-aaaba-cai",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "manual_memory_ids",
+            "action": "add",
+            "status": "updated",
+            "value": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+        })
+    );
+
+    let yaml = read_prefs_yaml(&config_dir);
+    assert!(yaml.contains("default_memory_id: aaaaa-aa"));
+    assert!(yaml.contains("- docs"));
+    assert!(yaml.contains("- keep"));
+    assert!(yaml.contains("- ryjl3-tyaaa-aaaaa-aaaba-cai"));
+    assert!(yaml.contains("chat_overall_top_k: 10"));
+    assert!(yaml.contains("chat_per_memory_cap: 4"));
+    assert!(yaml.contains("chat_mmr_lambda: 80"));
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "show"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "default_memory_id": "aaaaa-aa",
+            "saved_tags": ["docs", "keep"],
+            "manual_memory_ids": [
+                "yta6k-5x777-77774-aaaaa-cai",
+                "ryjl3-tyaaa-aaaaa-aaaba-cai"
+            ],
+        })
+    );
+}
+
+#[test]
+fn prefs_remove_commands_report_unchanged_when_entry_is_missing() {
+    let config_dir = temp_config_dir("remove-missing");
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "remove-tag", "--tag", "docs"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "saved_tags",
+            "action": "remove",
+            "status": "unchanged",
+            "value": "docs"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "remove-memory", "--memory-id", "aaaaa-aa"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "manual_memory_ids",
+            "action": "remove",
+            "status": "unchanged",
+            "value": "aaaaa-aa"
+        })
+    );
+}
+
+#[test]
+fn prefs_clear_default_memory_updates_yaml() {
+    let config_dir = temp_config_dir("clear-default");
+    let kinic_dir = app_config_root(&config_dir).join("kinic");
+    fs::create_dir_all(&kinic_dir).unwrap();
+    fs::write(
+        kinic_dir.join("tui.yaml"),
+        concat!(
+            "default_memory_id: aaaaa-aa\n",
+            "saved_tags: []\n",
+            "manual_memory_ids: []\n"
+        ),
+    )
+    .unwrap();
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "clear-default-memory"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "default_memory_id",
+            "action": "clear",
+            "status": "updated",
+            "value": null
+        })
+    );
+    let yaml = read_prefs_yaml(&config_dir);
+    assert!(!yaml.contains("default_memory_id: aaaaa-aa"));
+    assert!(yaml.contains("saved_tags: []"));
+    assert!(yaml.contains("manual_memory_ids: []"));
+}

--- a/tests/kinic_cli_tui.rs
+++ b/tests/kinic_cli_tui.rs
@@ -28,7 +28,7 @@ fn prefs_help_mentions_json_contract_and_examples() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("All prefs commands return JSON."));
-    assert!(stdout.contains("show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+    assert!(stdout.contains("show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[], \"chat_overall_top_k\": integer, \"chat_per_memory_cap\": integer, \"chat_mmr_lambda\": integer}"));
     assert!(stdout.contains("kinic-cli prefs set-default-memory --memory-id"));
 }
 
@@ -42,7 +42,7 @@ fn prefs_show_help_mentions_return_shape() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("Returns JSON."));
-    assert!(stdout.contains("{\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+    assert!(stdout.contains("{\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[], \"chat_overall_top_k\": integer, \"chat_per_memory_cap\": integer, \"chat_mmr_lambda\": integer}"));
 }
 
 #[test]

--- a/tests/kinic_cli_tui.rs
+++ b/tests/kinic_cli_tui.rs
@@ -1,6 +1,64 @@
 use std::process::Command;
 
 #[test]
+fn top_level_help_mentions_agent_entrypoints_and_auth_modes() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout
+            .contains("Network commands require --identity <NAME> or --ii unless noted otherwise.")
+    );
+    assert!(stdout.contains("kinic-cli capabilities"));
+    assert!(stdout.contains("kinic-cli prefs show"));
+    assert!(stdout.contains("capabilities and prefs commands return JSON."));
+}
+
+#[test]
+fn prefs_help_mentions_json_contract_and_examples() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("All prefs commands return JSON."));
+    assert!(stdout.contains("show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+    assert!(stdout.contains("kinic-cli prefs set-default-memory --memory-id"));
+}
+
+#[test]
+fn prefs_show_help_mentions_return_shape() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "show", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Returns JSON."));
+    assert!(stdout.contains("{\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+}
+
+#[test]
+fn prefs_mutation_help_mentions_status_shape() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "add-tag", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Returns JSON."));
+    assert!(stdout.contains("{\"resource\": \"saved_tags\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}"));
+}
+
+#[test]
 fn tui_help_mentions_global_identity_requirement() {
     let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
         .args(["tui", "--help"])
@@ -9,7 +67,8 @@ fn tui_help_mentions_global_identity_requirement() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("requires global --identity"));
+    assert!(stdout.contains("Requires global --identity."));
+    assert!(stdout.contains("--ii is not supported."));
     assert!(stdout.contains("kinic-cli --identity <IDENTITY> tui"));
 }
 

--- a/tests/kinic_cli_tui.rs
+++ b/tests/kinic_cli_tui.rs
@@ -46,6 +46,19 @@ fn prefs_show_help_mentions_return_shape() {
 }
 
 #[test]
+fn read_command_help_mentions_json_output_option() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["search", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--json"));
+    assert!(stdout.contains("Return machine-readable JSON output"));
+}
+
+#[test]
 fn prefs_mutation_help_mentions_status_shape() {
     let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
         .args(["prefs", "add-tag", "--help"])

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -9,8 +9,8 @@ use tui_kit_render::ui::{AnimationState, Focus, TabId, TuiKitUi, UiConfig};
 use tui_kit_runtime::{
     CoreAction, CoreEffect, CoreState, DataProvider, PaneFocus, PickerState, apply_snapshot,
     chat_commands::{
-        UNKNOWN_SLASH_COMMAND_MESSAGE, chat_slash_command_action, matching_slash_commands,
-        normalize_chat_input_lines, selected_slash_command_action,
+        UNKNOWN_SLASH_COMMAND_MESSAGE, chat_slash_command_action, flatten_chat_input_for_display,
+        matching_slash_commands, normalize_chat_input_lines, selected_slash_command_action,
     },
     dispatch_action, is_insert_form_locked,
     kinic_tabs::{
@@ -1009,7 +1009,7 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
 }
 
 fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
-    normalize_chat_input_lines(textarea.lines().join("\n").as_str())
+    flatten_chat_input_for_display(textarea.lines().join("\n").as_str())
 }
 
 fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
@@ -1027,7 +1027,7 @@ fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
         .map(|line| line.chars().take(cursor_col).collect::<String>())
         .unwrap_or_default();
     prefix_lines.push(current_prefix);
-    normalize_chat_input_lines(prefix_lines.join("\n").as_str())
+    flatten_chat_input_for_display(prefix_lines.join("\n").as_str())
         .chars()
         .count()
 }
@@ -1072,10 +1072,9 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let normalized_chat_input =
-        normalize_chat_input_lines(textareas.chat_input.lines().join("\n").as_str());
-    if state.chat_input != normalized_chat_input {
-        state.chat_input = normalized_chat_input;
+    let display_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+    if state.chat_input != display_chat_input {
+        state.chat_input = display_chat_input;
     }
 }
 

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -1,7 +1,7 @@
 #[path = "form_tab_flow.rs"]
 mod form_tab_flow;
 
-use ratatui_textarea::{Input as TextAreaInput, Key as TextAreaKey, TextArea};
+use ratatui_textarea::{CursorMove, Input as TextAreaInput, Key as TextAreaKey, TextArea};
 use std::{io, time::Duration};
 use tui_kit_render::theme::Theme;
 use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
@@ -159,6 +159,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             terminal.draw(|frame| {
                 let focus = ui_focus_from_pane(state.focus);
                 let insert_file_path_display = insert_file_path_display(&state);
+                let visible_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
                 let ui = TuiKitUi::new(&theme)
                     .ui_config(ui_config())
                     .ui_summaries(&state.list_items)
@@ -223,10 +224,9 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                     .filtered_context_indices(&[])
                     .candidates(&[])
                     .chat_messages(&state.chat_messages)
-                    .chat_input(&state.chat_input)
-                    .chat_input_cursor(textarea_cursor(
+                    .chat_input(visible_chat_input.as_str())
+                    .chat_input_cursor(chat_input_cursor(
                         active_textarea(&state),
-                        ActiveTextarea::ChatInput,
                         &textareas.chat_input,
                     ))
                     .chat_command_selected(chat_command_selection(&state, &textareas))
@@ -634,9 +634,8 @@ fn build_ui<'a>(
         .candidates(&[])
         .chat_messages(&state.chat_messages)
         .chat_input(&state.chat_input)
-        .chat_input_cursor(textarea_cursor(
+        .chat_input_cursor(chat_input_cursor(
             active_textarea(state),
-            ActiveTextarea::ChatInput,
             &textareas.chat_input,
         ))
         .chat_command_selected(chat_command_selection(state, textareas))
@@ -995,10 +994,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_textarea_from_string(
-        &mut textareas.chat_input,
-        normalize_chat_input_lines(state.chat_input.as_str()).as_str(),
-    );
+    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str());
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1010,6 +1006,51 @@ fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
 
 fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
+}
+
+fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
+    normalize_chat_input_lines(textarea.lines().join("\n").as_str())
+}
+
+fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
+    let lines = textarea.lines();
+    let last_row = lines.len().saturating_sub(1);
+    let (cursor_row, cursor_col) = textarea.cursor();
+    let effective_row = cursor_row.min(last_row);
+    let mut prefix_lines = lines
+        .iter()
+        .take(effective_row)
+        .map(|line| line.as_str().to_string())
+        .collect::<Vec<_>>();
+    let current_prefix = lines
+        .get(effective_row)
+        .map(|line| line.chars().take(cursor_col).collect::<String>())
+        .unwrap_or_default();
+    prefix_lines.push(current_prefix);
+    normalize_chat_input_lines(prefix_lines.join("\n").as_str())
+        .chars()
+        .count()
+}
+
+fn chat_input_cursor(
+    active: Option<ActiveTextarea>,
+    textarea: &TextArea<'static>,
+) -> Option<(usize, usize)> {
+    if active != Some(ActiveTextarea::ChatInput) {
+        return None;
+    }
+    Some((0, normalized_chat_cursor_col(textarea)))
+}
+
+fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str) {
+    // Chat input remains a single-line UI, but the widget may still hold raw pasted
+    // newlines or trailing spaces while editing. Only rebuild when the normalized
+    // text actually diverges so equivalent edits keep the cursor stable.
+    if normalized_chat_textarea_value(textarea) == value {
+        return;
+    }
+    sync_textarea_from_string(textarea, value);
+    textarea.move_cursor(CursorMove::End);
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -514,17 +514,77 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 }
 
 #[test]
-fn chat_textarea_multiline_paste_is_normalized_to_single_line() {
-    let mut state = CoreState {
-        chat_input: "first line\nsecond line".to_string(),
-        ..CoreState::default()
-    };
+fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
+    let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("first line\nsecond line");
 
-    sync_form_textareas_from_state(&mut textareas, &state);
     sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
 
     assert_eq!(state.chat_input, "first line second line");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line\nsecond line"
+    );
+}
+
+#[test]
+fn chat_textarea_sync_state_normalizes_trailing_space() {
+    let mut state = CoreState::default();
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+
+    sync_state_from_textareas(&mut state, &textareas);
+
+    assert_eq!(state.chat_input, "hello");
+}
+
+#[test]
+fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget() {
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+    let state = CoreState {
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+}
+
+#[test]
+fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
+    let mut textareas = FormTextareas::default();
+    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input.input(textarea_input_from_key_event(
+        crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Left,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    ));
+    let cursor_before = textareas.chat_input.cursor();
+    let state = CoreState {
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+    assert_eq!(textareas.chat_input.cursor(), cursor_before);
+}
+
+#[test]
+fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
+    let mut textarea = textarea_from_text("first line\nsecond line");
+    textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
+
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 17))
+    );
 }
 
 #[test]
@@ -723,6 +783,33 @@ fn chat_submit_slash_all_switches_scope_without_sending_message() {
 }
 
 #[test]
+fn chat_submit_normalizes_multiline_input_before_sending_message() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+    sync_state_from_textareas(&mut state, &textareas);
+
+    let handled =
+        handle_chat_submit_or_command(&mut provider, &mut state, &mut hooks, &mut textareas)
+            .expect("chat submit");
+
+    assert!(handled);
+    assert_eq!(
+        state.chat_messages,
+        vec![("user".to_string(), "first line second line".to_string())]
+    );
+    assert!(state.chat_input.is_empty());
+}
+
+#[test]
 fn chat_submit_slash_all_is_idempotent_when_already_on_all_scope() {
     let mut provider = TestProvider::ok();
     let mut hooks = NoopRuntimeHooks;
@@ -731,6 +818,29 @@ fn chat_submit_slash_all_is_idempotent_when_already_on_all_scope() {
         focus: PaneFocus::Extra,
         chat_input: "/all".to_string(),
         chat_scope: tui_kit_runtime::ChatScope::All,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+
+    let handled =
+        handle_chat_submit_or_command(&mut provider, &mut state, &mut hooks, &mut textareas)
+            .expect("slash command");
+
+    assert!(handled);
+    assert_eq!(state.chat_scope, tui_kit_runtime::ChatScope::All);
+    assert!(state.chat_messages.is_empty());
+    assert!(state.chat_input.is_empty());
+}
+
+#[test]
+fn chat_submit_slash_all_trims_trailing_space_before_matching_command() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "/all ".to_string(),
+        chat_scope: tui_kit_runtime::ChatScope::Selected,
         ..CoreState::default()
     };
     let mut textareas = FormTextareas::default();

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -530,14 +530,27 @@ fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
 }
 
 #[test]
-fn chat_textarea_sync_state_normalizes_trailing_space() {
+fn chat_textarea_sync_state_preserves_trailing_space() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("hello ");
 
     sync_state_from_textareas(&mut state, &textareas);
 
-    assert_eq!(state.chat_input, "hello");
+    assert_eq!(state.chat_input, "hello ");
+}
+
+#[test]
+fn chat_textarea_display_value_preserves_trailing_space() {
+    let textareas = FormTextareas {
+        chat_input: textarea_from_text("hello "),
+        ..FormTextareas::default()
+    };
+
+    assert_eq!(
+        normalized_chat_textarea_value(&textareas.chat_input),
+        "hello "
+    );
 }
 
 #[test]
@@ -545,7 +558,7 @@ fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget()
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("hello ");
     let state = CoreState {
-        chat_input: "hello".to_string(),
+        chat_input: "hello ".to_string(),
         ..CoreState::default()
     };
 
@@ -566,7 +579,7 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
     ));
     let cursor_before = textareas.chat_input.cursor();
     let state = CoreState {
-        chat_input: "hello".to_string(),
+        chat_input: "hello ".to_string(),
         ..CoreState::default()
     };
 
@@ -574,6 +587,17 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
 
     assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
     assert_eq!(textareas.chat_input.cursor(), cursor_before);
+}
+
+#[test]
+fn chat_input_cursor_keeps_trailing_space_visible() {
+    let mut textarea = textarea_from_text("hello ");
+    textarea.move_cursor(ratatui_textarea::CursorMove::End);
+
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 6))
+    );
 }
 
 #[test]
@@ -585,6 +609,79 @@ fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
         Some((0, 17))
     );
+}
+
+#[test]
+fn chat_textarea_display_value_keeps_space_before_next_char() {
+    let textareas = FormTextareas {
+        chat_input: textarea_from_text("hello w"),
+        ..FormTextareas::default()
+    };
+
+    assert_eq!(
+        normalized_chat_textarea_value(&textareas.chat_input),
+        "hello w"
+    );
+}
+
+#[test]
+fn chat_textarea_space_input_updates_state_and_widget_cursor() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "hello".to_string(),
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat textarea input");
+
+    assert!(handled);
+    assert_eq!(state.chat_input, "hello ");
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello ");
+    assert_eq!(textareas.chat_input.cursor(), (0, 6));
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textareas.chat_input),
+        Some((0, 6))
+    );
+}
+
+#[test]
+fn build_ui_places_chat_cursor_after_trailing_space() {
+    let theme = Theme::default();
+    let cfg = test_runtime_config();
+    let animation = AnimationState::new();
+    let state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "hello ".to_string(),
+        chat_open: true,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let ui = build_ui(
+        &theme, &cfg, &state, &textareas, 0, 0, false, false, &animation,
+    );
+    let cursor = ui.cursor_position_for_area(Rect::new(0, 0, 120, 40));
+
+    assert!(cursor.is_some());
+    let (x, _) = cursor.expect("chat cursor");
+    assert!(x > 0);
 }
 
 #[test]

--- a/tui/crates/tui-kit-render/src/ui/app/screens/memories/chat_panel.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/screens/memories/chat_panel.rs
@@ -14,7 +14,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::ui::app::{Focus, TuiKitUi};
 use crate::ui::theme::Theme;
-use tui_kit_runtime::chat_commands::{matching_slash_commands, normalize_chat_input_lines};
+use tui_kit_runtime::chat_commands::{flatten_chat_input_for_display, matching_slash_commands};
 
 pub(super) const CHAT_INPUT_MAX_HEIGHT: u16 = 1;
 
@@ -460,7 +460,7 @@ pub(super) fn visible_chat_input_rows(
     cursor_col: usize,
     max_width: u16,
 ) -> VisibleChatInputRows {
-    let single_line_value = normalize_chat_input_lines(value);
+    let single_line_value = flatten_chat_input_for_display(value);
     let mut source_rows = if single_line_value.is_empty() {
         vec![placeholder.to_string()]
     } else {

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -13,17 +13,18 @@ pub const UNKNOWN_SLASH_COMMAND_MESSAGE: &str = "Unknown chat command. Try /new 
 
 /// Commands whose prefix matches `input` (trimmed), for autocomplete UI.
 pub fn matching_slash_commands(input: &str) -> Vec<&'static str> {
-    let trimmed = input.trim();
-    if !trimmed.starts_with('/') {
+    let trimmed_end = input.trim_end();
+    let command_input = trimmed_end.trim_start();
+    if !command_input.starts_with('/') {
         return Vec::new();
     }
-    if trimmed == "/" {
+    if command_input == "/" {
         return CHAT_SLASH_COMMANDS.to_vec();
     }
     CHAT_SLASH_COMMANDS
         .iter()
         .copied()
-        .filter(|command| command.starts_with(trimmed))
+        .filter(|command| command.starts_with(command_input))
         .collect()
 }
 
@@ -43,6 +44,12 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
         .and_then(chat_slash_command_action)
 }
 
+/// Collapse multiline chat input to one line for in-progress display.
+/// This preserves user-typed spacing and only replaces line breaks with spaces.
+pub fn flatten_chat_input_for_display(value: &str) -> String {
+    value.split('\n').collect::<Vec<_>>().join(" ")
+}
+
 /// Collapse multiline chat input to one line (trimmed lines joined with spaces).
 pub fn normalize_chat_input_lines(value: &str) -> String {
     value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
@@ -55,8 +62,14 @@ mod tests {
     #[test]
     fn matching_slash_commands_filters_by_prefix() {
         assert_eq!(matching_slash_commands("/"), vec!["/new", "/all"]);
+        assert_eq!(matching_slash_commands("/all "), vec!["/all"]);
         assert!(matching_slash_commands("/s").is_empty());
         assert!(matching_slash_commands("hello").is_empty());
+    }
+
+    #[test]
+    fn flatten_chat_input_for_display_preserves_spacing() {
+        assert_eq!(flatten_chat_input_for_display("a \n  b"), "a    b");
     }
 
     #[test]


### PR DESCRIPTION
### Summary

- Added kinic-cli capabilities
- Added kinic-cli prefs
- Expanded top-level and subcommand help text
- Allowed capabilities and prefs to run without --identity
- Centralized persistence for TUI-shared local preferences
- Added CLI tests for capabilities and prefs
- Updated docs/cli.md with usage examples and JSON contracts
- add CLI commands for memory management and preferences, including chat retrieval controls
- add JSON output support for read-oriented CLI commands and wire the new command surfaces through shared helpers
- update TUI/runtime integration, documentation, and user skill guidance to reflect the expanded CLI behavior
- add and adjust command, prefs, capabilities, and TUI test coverage

### New commands

- kinic-cli capabilities
- kinic-cli prefs show
- kinic-cli prefs set-default-memory --memory-id <MEMORY_ID>
- kinic-cli prefs clear-default-memory
- kinic-cli prefs add-tag --tag <TAG>
- kinic-cli prefs remove-tag --tag <TAG>
- kinic-cli prefs add-memory --memory-id <MEMORY_ID>
- kinic-cli prefs remove-memory --memory-id <MEMORY_ID>

### Why

- Let agents inspect command structure, auth requirements, output modes, and major arguments before choosing how to invoke the CLI
- Let users and tools manage the same local preferences used by the TUI
- Make CLI usage constraints clearer directly from --help