### PR TITLE
Add chat paste input support across the TUI and CLI settings flows

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,51 @@ Command-line companion for deploying and operating Kinic “memory” canisters.
 
 Use either `--identity` (dfx identity name stored in the system keychain) or `--ii` (Internet Identity login). Use `--ic` to talk to mainnet; omit it (or leave false) for the local replica. If you are not using `--ii`, `--identity <name>` is required for CLI commands.
 
+Agent-friendly discovery tips:
+- Start with `kinic-cli --help` for auth mode guidance and top-level entrypoints
+- Start with `kinic-cli capabilities` to get a JSON description of commands, auth requirements, output modes, major arguments, and arg-group constraints
+- Use `kinic-cli prefs --help` to inspect the JSON contract for shared local preferences
+- `capabilities` and `prefs` commands return JSON; existing network commands currently keep text output
+
+### Capabilities JSON
+
+Use this command when an agent needs a machine-readable description of the CLI before choosing a command:
+
+```bash
+cargo run -- capabilities
+```
+
+Example output:
+
+```json
+{
+  "cli": "kinic-cli",
+  "version": "0.1.2",
+  "auth_summary": "Network commands require --identity or --ii unless noted otherwise. The TUI requires --identity.",
+  "commands": [
+    {
+      "name": "prefs",
+      "summary": "Manage local Kinic preferences shared with the TUI.",
+      "requires_auth": false,
+      "auth_modes": [],
+      "output_mode": "json",
+      "interactive": false,
+      "arguments": [],
+      "subcommands": [
+        {
+          "name": "show",
+          "summary": "Show local preferences shared with the TUI.",
+          "output_mode": "json",
+          "arguments": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+For commands with compound input rules, `capabilities` also includes `arg_groups`. For example, `insert` exposes the required `insert_input` group so an agent can see that one of `text` or `file_path` must be provided. Arguments may also include `relations` with `requires` and `conflicts` when those constraints are available.
+
 ```bash
 cargo run -- --identity alice list
 cargo run -- --identity alice create \
@@ -138,6 +183,61 @@ cargo run -- --identity alice config \
 Notes:
 - `anonymous` assigns the role to everyone; admin cannot be granted to `anonymous`.
 - Principals are validated; invalid text fails fast.
+
+### Manage local preferences shared with the TUI
+
+These commands read and write the same local settings file used by the TUI at `~/.config/kinic/tui.yaml`.
+They do not require `--identity` because they only update local preferences.
+`prefs show` returns JSON so it can be consumed reliably by AI agents, shell scripts, and other tools.
+All `prefs` commands now return JSON so agents can consume both reads and mutations with one stable contract.
+
+Show the current shared preferences:
+
+```bash
+cargo run -- prefs show
+```
+
+Example output:
+
+```json
+{
+  "default_memory_id": null,
+  "saved_tags": [],
+  "manual_memory_ids": []
+}
+```
+
+Set or clear the default memory:
+
+```bash
+cargo run -- prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+cargo run -- prefs clear-default-memory
+```
+
+Example mutation output:
+
+```json
+{
+  "resource": "default_memory_id",
+  "action": "set",
+  "status": "updated",
+  "value": "yta6k-5x777-77774-aaaaa-cai"
+}
+```
+
+Manage saved tags:
+
+```bash
+cargo run -- prefs add-tag --tag quarterly_report
+cargo run -- prefs remove-tag --tag quarterly_report
+```
+
+Manage manually tracked memories:
+
+```bash
+cargo run -- prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+cargo run -- prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai
+```
 
 ### Update a memory canister instance
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -279,7 +279,7 @@ Main items you can review:
 - `d` in the saved tag list: delete a tag
 - `Ctrl+R`: refresh `Principal ID` and `KINIC balance`
 
-The transfer modal accepts a recipient principal and an amount in KINIC. `Max` fills the largest sendable amount after subtracting the current ledger fee, and `Submit` opens a confirmation step before the transfer is sent.
+The transfer modal accepts a recipient principal and an amount in KINIC. The amount field accepts digits and a single decimal point, with up to 8 fractional digits. `Max` fills the largest sendable amount after subtracting the current ledger fee, and `Submit` opens a confirmation step before the transfer is sent.
 
 Values saved from `Settings` persist across restarts.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -84,6 +84,7 @@ The TUI has five tabs.
 - `Settings`: view and change current connection info and saved settings
 
 The `Memories` tab opens first when the TUI starts.
+The local preferences shown in `Settings`, including the default memory, saved tags, and manually tracked memories, can also be managed from the CLI with `kinic-cli prefs ...`.
 
 ## Basic Controls
 

--- a/rust/cli_defs.rs
+++ b/rust/cli_defs.rs
@@ -14,7 +14,8 @@ pub fn parse_identity_arg(value: &str) -> Result<String, String> {
 #[command(
     name = "kinic-cli",
     version,
-    about = "Kinic developer CLI for deploying and managing memories"
+    about = "Kinic developer CLI for memory operations and agent-friendly local preferences",
+    after_help = "Auth modes:\n  Network commands require --identity <NAME> or --ii unless noted otherwise.\n  The TUI requires --identity <NAME> and does not support --ii.\n\nAgent entrypoints:\n  kinic-cli capabilities\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id <MEMORY_ID>\n\nReturns:\n  capabilities and prefs commands return JSON.\n  Existing network commands keep their current text output."
 )]
 pub struct Cli {
     #[command(flatten)]
@@ -59,42 +60,83 @@ pub struct GlobalOpts {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    #[command(about = "Deploy a new memory canister via the launcher")]
+    #[command(
+        about = "Deploy a new memory canister. Requires --identity or --ii. Returns text output."
+    )]
     Create(CreateArgs),
-    #[command(about = "List deployed memories and their principals")]
+    #[command(about = "List deployed memories. Requires --identity or --ii. Returns text output.")]
     List(ListArgs),
-    #[command(about = "Insert text into an existing memory canister")]
+    #[command(
+        about = "Insert text into an existing memory canister. Requires --identity or --ii. Returns text output."
+    )]
     Insert(InsertArgs),
-    #[command(about = "Insert a precomputed embedding into a memory canister")]
+    #[command(
+        about = "Insert a precomputed embedding into a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     InsertRaw(InsertRawArgs),
-    #[command(about = "Insert a PDF (converted to markdown) into an existing memory canister")]
+    #[command(
+        about = "Insert a PDF converted to markdown into a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     InsertPdf(InsertPdfArgs),
-    #[command(about = "Convert a PDF to markdown and print it (no insert)")]
+    #[command(
+        about = "Convert a PDF to markdown and print it. No identity required. Returns text output."
+    )]
     ConvertPdf(ConvertPdfArgs),
-    #[command(about = "Search within a memory canister using embeddings")]
+    #[command(
+        about = "Search within a memory canister using embeddings. Requires --identity or --ii. Returns text output."
+    )]
     Search(SearchArgs),
-    #[command(about = "Search within a memory canister using a precomputed embedding")]
+    #[command(
+        about = "Search within a memory canister using a precomputed embedding. Requires --identity or --ii. Returns text output."
+    )]
     SearchRaw(SearchRawArgs),
-    #[command(about = "Fetch embeddings for a tag from a memory canister")]
+    #[command(
+        about = "Fetch embeddings for a tag from a memory canister. Requires --identity or --ii. Returns text output."
+    )]
     TaggedEmbeddings(TaggedEmbeddingsArgs),
-    #[command(about = "Manage Kinic CLI configuration")]
+    #[command(
+        about = "Manage memory access control. Requires --identity or --ii. Returns text output."
+    )]
     Config(ConfigArgs),
-    #[command(about = "Update a memory canister instance")]
+    #[command(
+        about = "Describe CLI capabilities for agents. Returns JSON.",
+        after_help = "Returns:\n  JSON with top-level commands, auth requirements, output modes, and major arguments.\n\nExample:\n  kinic-cli capabilities"
+    )]
+    Capabilities(CapabilitiesArgs),
+    #[command(
+        about = "Manage local Kinic preferences shared with the TUI. All prefs commands return JSON.",
+        after_help = "Examples:\n  kinic-cli prefs show\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai\n\nReturns:\n  show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n  mutations -> {\"resource\": string, \"action\": string, \"status\": \"updated\"|\"unchanged\", \"value\": string|null}"
+    )]
+    Prefs(PrefsArgs),
+    #[command(
+        about = "Update a memory canister instance. Requires --identity or --ii. Returns text output."
+    )]
     Update(UpdateArgs),
-    #[command(about = "Reset a memory canister and set embedding dimension")]
+    #[command(
+        about = "Reset a memory canister and set embedding dimension. Requires --identity or --ii. Returns text output."
+    )]
     Reset(ResetArgs),
-    #[command(about = "Check KINIC token balance for the current identity")]
+    #[command(
+        about = "Check KINIC token balance. Requires --identity or --ii. Returns text output."
+    )]
     Balance(BalanceArgs),
-    #[command(about = "Ask Kinic AI using memory search results (LLM placeholder)")]
+    #[command(
+        about = "Ask Kinic AI using memory search results. Requires --identity or --ii. Returns text output."
+    )]
     AskAi(AskAiArgs),
-    #[command(about = "Login via Internet Identity and store a delegation")]
+    #[command(
+        about = "Login via Internet Identity and store a delegation. No identity required. Returns text output."
+    )]
     Login(LoginArgs),
     #[command(
-        about = "Launch the Kinic terminal UI (requires global --identity)",
-        after_help = "Required invocation:\n  kinic-cli --identity <IDENTITY> tui"
+        about = "Launch the Kinic terminal UI. Requires global --identity. --ii is not supported. Returns an interactive TUI, not JSON.",
+        after_help = "Requires:\n  kinic-cli --identity <IDENTITY> tui\n\nReturns:\n  Interactive terminal UI.\n\nExample:\n  kinic-cli --identity alice tui"
     )]
     Tui(TuiArgs),
 }
+
+#[derive(Args, Debug, Default)]
+pub struct CapabilitiesArgs {}
 
 #[derive(Args, Debug)]
 pub struct CreateArgs {
@@ -253,6 +295,77 @@ pub struct ConfigArgs {
         help = "Add a user with role to the Kinic CLI config (placeholder)"
     )]
     pub add_user: Option<Vec<String>>,
+}
+
+#[derive(Args, Debug)]
+pub struct PrefsArgs {
+    #[command(subcommand)]
+    pub command: PrefsCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PrefsCommand {
+    #[command(
+        about = "Show local preferences shared with the TUI. Returns JSON.",
+        after_help = "Returns:\n  {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}\n\nExample:\n  kinic-cli prefs show"
+    )]
+    Show,
+    #[command(
+        about = "Set the default memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"default_memory_id\", \"action\": \"set\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs set-default-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    SetDefaultMemory(SetDefaultMemoryArgs),
+    #[command(
+        about = "Clear the default memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"default_memory_id\", \"action\": \"clear\", \"status\": \"updated\"|\"unchanged\", \"value\": null}\n\nExample:\n  kinic-cli prefs clear-default-memory"
+    )]
+    ClearDefaultMemory,
+    #[command(
+        about = "Add a saved tag. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"saved_tags\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs add-tag --tag quarterly_report"
+    )]
+    AddTag(TagArgs),
+    #[command(
+        about = "Remove a saved tag. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"saved_tags\", \"action\": \"remove\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs remove-tag --tag quarterly_report"
+    )]
+    RemoveTag(TagArgs),
+    #[command(
+        about = "Add a manually tracked memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs add-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    AddMemory(MemoryIdArgs),
+    #[command(
+        about = "Remove a manually tracked memory id. Returns JSON.",
+        after_help = "Returns:\n  {\"resource\": \"manual_memory_ids\", \"action\": \"remove\", \"status\": \"updated\"|\"unchanged\", \"value\": string}\n\nExample:\n  kinic-cli prefs remove-memory --memory-id yta6k-5x777-77774-aaaaa-cai"
+    )]
+    RemoveMemory(MemoryIdArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SetDefaultMemoryArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the default memory canister"
+    )]
+    pub memory_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct TagArgs {
+    #[arg(long, required = true, help = "Tag value to add or remove")]
+    pub tag: String,
+}
+
+#[derive(Args, Debug)]
+pub struct MemoryIdArgs {
+    #[arg(
+        long,
+        required = true,
+        help = "Principal of the memory canister to add or remove"
+    )]
+    pub memory_id: String,
 }
 
 #[derive(Args, Debug)]

--- a/rust/commands/capabilities.rs
+++ b/rust/commands/capabilities.rs
@@ -1,0 +1,380 @@
+//! Agent-readable capability description for the Kinic CLI.
+//! Where: top-level `capabilities` command.
+//! What: builds JSON from clap command definitions plus a small semantic overlay.
+//! Why: reduces drift between CLI parsing and agent-facing discovery metadata.
+
+use anyhow::Result;
+use clap::{Arg, ArgGroup, Command, CommandFactory};
+use serde::Serialize;
+
+use crate::cli::{CapabilitiesArgs, Cli};
+
+pub fn handle(_args: CapabilitiesArgs) -> Result<()> {
+    let payload = CapabilitiesDocument::new();
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct CapabilitiesDocument {
+    cli: &'static str,
+    version: &'static str,
+    auth_summary: &'static str,
+    commands: Vec<CommandCapability>,
+}
+
+impl CapabilitiesDocument {
+    fn new() -> Self {
+        Self {
+            cli: "kinic-cli",
+            version: env!("CARGO_PKG_VERSION"),
+            auth_summary: "Network commands require --identity or --ii unless noted otherwise. The TUI requires --identity.",
+            commands: command_capabilities(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CommandCapability {
+    name: String,
+    summary: String,
+    requires_auth: bool,
+    auth_modes: Vec<&'static str>,
+    output_mode: &'static str,
+    interactive: bool,
+    arguments: Vec<ArgumentCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arg_groups: Vec<ArgGroupCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subcommands: Vec<SubcommandCapability>,
+}
+
+#[derive(Debug, Serialize)]
+struct SubcommandCapability {
+    name: String,
+    summary: String,
+    output_mode: &'static str,
+    arguments: Vec<ArgumentCapability>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arg_groups: Vec<ArgGroupCapability>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ArgumentCapability {
+    name: String,
+    required: bool,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "ArgumentRelations::is_empty")]
+    relations: ArgumentRelations,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, Default)]
+struct ArgumentRelations {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    requires: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conflicts: Vec<String>,
+}
+
+impl ArgumentRelations {
+    fn is_empty(&self) -> bool {
+        self.requires.is_empty() && self.conflicts.is_empty()
+    }
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct ArgGroupCapability {
+    id: String,
+    required: bool,
+    multiple: bool,
+    members: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+struct CommandMetadata {
+    auth_modes: &'static [&'static str],
+    output_mode: &'static str,
+    interactive: bool,
+}
+
+fn command_capabilities() -> Vec<CommandCapability> {
+    Cli::command()
+        .get_subcommands()
+        .map(|command| {
+            let metadata = command_metadata(command.get_name());
+            CommandCapability {
+                name: command.get_name().to_string(),
+                summary: command_summary(command),
+                requires_auth: !metadata.auth_modes.is_empty(),
+                auth_modes: metadata.auth_modes.to_vec(),
+                output_mode: metadata.output_mode,
+                interactive: metadata.interactive,
+                arguments: argument_capabilities(command, command.get_name()),
+                arg_groups: arg_group_capabilities(command),
+                subcommands: subcommand_capabilities(command, metadata.output_mode),
+            }
+        })
+        .collect()
+}
+
+fn subcommand_capabilities(
+    command: &Command,
+    parent_output_mode: &'static str,
+) -> Vec<SubcommandCapability> {
+    command
+        .get_subcommands()
+        .map(|subcommand| {
+            let path = format!("{}.{}", command.get_name(), subcommand.get_name());
+            SubcommandCapability {
+                name: subcommand.get_name().to_string(),
+                summary: command_summary(subcommand),
+                output_mode: subcommand_output_mode(&path, parent_output_mode),
+                arguments: argument_capabilities(subcommand, &path),
+                arg_groups: arg_group_capabilities(subcommand),
+            }
+        })
+        .collect()
+}
+
+fn argument_capabilities(command: &Command, path: &str) -> Vec<ArgumentCapability> {
+    command
+        .get_arguments()
+        .filter_map(|arg| public_argument(command, arg, path))
+        .collect()
+}
+
+fn public_argument(command: &Command, arg: &Arg, path: &str) -> Option<ArgumentCapability> {
+    let name = arg.get_id().as_str();
+    if matches!(name, "help" | "version") || arg.get_long().is_none() {
+        return None;
+    }
+    Some(ArgumentCapability {
+        name: name.to_string(),
+        required: arg.is_required_set(),
+        kind: argument_kind(path, name),
+        relations: argument_relations(command, arg, path),
+    })
+}
+
+fn argument_relations(command: &Command, arg: &Arg, path: &str) -> ArgumentRelations {
+    let mut relations = manual_argument_relations(path, arg.get_id().as_str());
+    relations.conflicts.extend(
+        command
+            .get_arg_conflicts_with(arg)
+            .into_iter()
+            .filter(|conflict| conflict.get_long().is_some())
+            .map(|conflict| conflict.get_id().as_str().to_string()),
+    );
+    relations
+}
+
+fn manual_argument_relations(path: &str, name: &str) -> ArgumentRelations {
+    let _ = (path, name);
+    ArgumentRelations::default()
+}
+
+fn command_summary(command: &Command) -> String {
+    command
+        .get_long_about()
+        .or_else(|| command.get_about())
+        .map(|value| value.to_string())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn arg_group_capabilities(command: &Command) -> Vec<ArgGroupCapability> {
+    let public_argument_names: Vec<&str> = command
+        .get_arguments()
+        .filter(|arg| arg.get_long().is_some())
+        .map(|arg| arg.get_id().as_str())
+        .collect();
+    command
+        .get_groups()
+        .filter(|group| is_public_arg_group(group, &public_argument_names))
+        .map(public_arg_group)
+        .collect()
+}
+
+fn public_arg_group(group: &ArgGroup) -> ArgGroupCapability {
+    let mut group = group.clone();
+    ArgGroupCapability {
+        id: group.get_id().as_str().to_string(),
+        required: group.is_required_set(),
+        multiple: group.is_multiple(),
+        members: group
+            .get_args()
+            .map(|member| member.as_str().to_string())
+            .collect(),
+    }
+}
+
+fn is_public_arg_group(group: &ArgGroup, public_argument_names: &[&str]) -> bool {
+    let member_names: Vec<&str> = group.get_args().map(|member| member.as_str()).collect();
+    !(group.get_id().as_str().ends_with("Args")
+        && !group.is_required_set()
+        && member_names == public_argument_names)
+}
+
+fn command_metadata(name: &str) -> CommandMetadata {
+    match name {
+        "convert-pdf" | "capabilities" | "prefs" | "login" => CommandMetadata {
+            auth_modes: &[],
+            output_mode: if name == "capabilities" || name == "prefs" {
+                "json"
+            } else {
+                "text"
+            },
+            interactive: false,
+        },
+        "tui" => CommandMetadata {
+            auth_modes: &["identity"],
+            output_mode: "interactive",
+            interactive: true,
+        },
+        _ => CommandMetadata {
+            auth_modes: &["identity", "ii"],
+            output_mode: "text",
+            interactive: false,
+        },
+    }
+}
+
+fn subcommand_output_mode(path: &str, parent_output_mode: &'static str) -> &'static str {
+    match path {
+        "prefs.show"
+        | "prefs.set-default-memory"
+        | "prefs.clear-default-memory"
+        | "prefs.add-tag"
+        | "prefs.remove-tag"
+        | "prefs.add-memory"
+        | "prefs.remove-memory" => "json",
+        _ => parent_output_mode,
+    }
+}
+
+fn argument_kind(path: &str, name: &str) -> &'static str {
+    match (path, name) {
+        (_, "memory_id") => "principal",
+        (_, "file_path") => "path",
+        (_, "embedding") => "json_array",
+        (_, "top_k" | "dim") => "integer",
+        ("config", "add_user") => "principal_role_pair",
+        _ => "string",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, CommandFactory};
+
+    use super::*;
+    use crate::cli::Cli;
+
+    #[test]
+    fn capabilities_document_matches_top_level_clap_commands() {
+        let document = CapabilitiesDocument::new();
+        let clap_names: Vec<String> = Cli::command()
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect();
+        let capability_names: Vec<String> = document
+            .commands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect();
+
+        assert_eq!(capability_names, clap_names);
+    }
+
+    #[test]
+    fn capabilities_document_describes_prefs_subcommands_from_clap() {
+        let document = CapabilitiesDocument::new();
+        let prefs = document
+            .commands
+            .iter()
+            .find(|command| command.name == "prefs")
+            .expect("prefs command should exist");
+        let clap = Cli::command();
+        let clap_prefs = clap
+            .get_subcommands()
+            .find(|command| command.get_name() == "prefs")
+            .expect("prefs should exist in clap");
+        let clap_subcommands: Vec<String> = clap_prefs
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect();
+        let capability_subcommands: Vec<String> = prefs
+            .subcommands
+            .iter()
+            .map(|command| command.name.clone())
+            .collect();
+
+        assert_eq!(capability_subcommands, clap_subcommands);
+        assert_eq!(prefs.output_mode, "json");
+    }
+
+    #[test]
+    fn capabilities_document_marks_tui_as_interactive_identity_only() {
+        let document = CapabilitiesDocument::new();
+        let tui = document
+            .commands
+            .iter()
+            .find(|command| command.name == "tui")
+            .expect("tui command should exist");
+
+        assert!(tui.requires_auth);
+        assert_eq!(tui.auth_modes, ["identity"]);
+        assert_eq!(tui.output_mode, "interactive");
+        assert!(tui.interactive);
+    }
+
+    #[test]
+    fn capabilities_document_includes_insert_arg_group_constraints() {
+        let document = CapabilitiesDocument::new();
+        let insert = document
+            .commands
+            .iter()
+            .find(|command| command.name == "insert")
+            .expect("insert command should exist");
+
+        assert_eq!(
+            insert.arg_groups,
+            vec![ArgGroupCapability {
+                id: "insert_input".to_string(),
+                required: true,
+                multiple: false,
+                members: vec!["text".to_string(), "file_path".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn argument_relations_capture_public_conflicts() {
+        let command = Command::new("demo")
+            .arg(Arg::new("alpha").long("alpha").conflicts_with("beta"))
+            .arg(Arg::new("beta").long("beta"));
+        let alpha = command
+            .get_arguments()
+            .find(|arg| arg.get_id().as_str() == "alpha")
+            .expect("alpha should exist");
+
+        let relations = argument_relations(&command, alpha, "demo");
+
+        assert_eq!(
+            relations,
+            ArgumentRelations {
+                requires: Vec::new(),
+                conflicts: vec!["beta".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn manual_argument_relations_default_to_empty_overlay() {
+        assert_eq!(
+            manual_argument_relations("insert", "text"),
+            ArgumentRelations::default()
+        );
+    }
+}

--- a/rust/commands/mod.rs
+++ b/rust/commands/mod.rs
@@ -4,6 +4,7 @@ use crate::{agent::AgentFactory, cli::Command};
 
 pub mod ask_ai;
 pub mod balance;
+pub mod capabilities;
 pub mod config;
 pub mod convert_pdf;
 pub mod create;
@@ -12,6 +13,7 @@ pub mod insert;
 pub mod insert_pdf;
 pub mod insert_raw;
 pub mod list;
+pub mod prefs;
 pub mod reset;
 pub mod search;
 pub mod search_raw;
@@ -36,6 +38,10 @@ pub async fn run_command(command: Command, ctx: CommandContext) -> Result<()> {
         Command::TaggedEmbeddings(args) => tagged_embeddings::handle(args, &ctx).await,
         Command::ConvertPdf(args) => convert_pdf::handle(args).await,
         Command::Config(args) => config::handle(args, &ctx).await,
+        Command::Capabilities(_) => {
+            unreachable!("capabilities command is handled before agent setup")
+        }
+        Command::Prefs(_) => unreachable!("prefs command is handled before agent setup"),
         Command::Update(args) => update::handle(args, &ctx).await,
         Command::Reset(args) => reset::handle(args, &ctx).await,
         Command::Balance(args) => balance::handle(args, &ctx).await,

--- a/rust/commands/prefs.rs
+++ b/rust/commands/prefs.rs
@@ -1,0 +1,321 @@
+//! Local preferences management for CLI/TUI shared settings.
+//! Where: command handler used by the top-level `prefs` CLI subcommand.
+//! What: reads and writes the TUI-backed YAML preferences for default memory, tags, and manual memories.
+//! Why: keep the TUI as the single persistence layer while letting CLI users manage the same settings.
+
+use anyhow::{Context, Result, bail};
+use ic_agent::export::Principal;
+use serde::Serialize;
+
+use crate::{
+    cli::{MemoryIdArgs, PrefsArgs, PrefsCommand, SetDefaultMemoryArgs, TagArgs},
+    preferences::{self, UserPreferences},
+};
+
+pub fn handle(args: PrefsArgs) -> Result<()> {
+    match args.command {
+        PrefsCommand::Show => show_preferences(),
+        PrefsCommand::SetDefaultMemory(args) => set_default_memory(args),
+        PrefsCommand::ClearDefaultMemory => clear_default_memory(),
+        PrefsCommand::AddTag(args) => add_tag(args),
+        PrefsCommand::RemoveTag(args) => remove_tag(args),
+        PrefsCommand::AddMemory(args) => add_memory(args),
+        PrefsCommand::RemoveMemory(args) => remove_memory(args),
+    }
+}
+
+fn show_preferences() -> Result<()> {
+    let preferences = load_preferences()?;
+    let json = serde_json::to_string_pretty(&ShowPreferences::from(preferences))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn set_default_memory(args: SetDefaultMemoryArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences.default_memory_id.as_deref() == Some(memory_id.as_str()) {
+        return print_json_response(PrefsResponse::unchanged(
+            "default_memory_id",
+            "set",
+            Some(memory_id),
+        ));
+    }
+
+    preferences.default_memory_id = Some(memory_id.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "default_memory_id",
+        "set",
+        Some(memory_id),
+    ))
+}
+
+fn clear_default_memory() -> Result<()> {
+    let mut preferences = load_preferences()?;
+    if preferences.default_memory_id.is_none() {
+        return print_json_response(PrefsResponse::unchanged(
+            "default_memory_id",
+            "clear",
+            Option::<String>::None,
+        ));
+    }
+
+    preferences.default_memory_id = None;
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "default_memory_id",
+        "clear",
+        Option::<String>::None,
+    ))
+}
+
+fn add_tag(args: TagArgs) -> Result<()> {
+    let tag = validate_tag(args.tag.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences.saved_tags.iter().any(|saved| saved == &tag) {
+        return print_json_response(PrefsResponse::unchanged("saved_tags", "add", Some(tag)));
+    }
+
+    preferences.saved_tags.push(tag.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("saved_tags", "add", Some(tag)))
+}
+
+fn remove_tag(args: TagArgs) -> Result<()> {
+    let tag = validate_tag(args.tag.as_str())?;
+    let mut preferences = load_preferences()?;
+    let original_len = preferences.saved_tags.len();
+    preferences.saved_tags.retain(|saved| saved != &tag);
+
+    if preferences.saved_tags.len() == original_len {
+        return print_json_response(PrefsResponse::unchanged("saved_tags", "remove", Some(tag)));
+    }
+
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated("saved_tags", "remove", Some(tag)))
+}
+
+fn add_memory(args: MemoryIdArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    if preferences
+        .manual_memory_ids
+        .iter()
+        .any(|saved| saved == &memory_id)
+    {
+        return print_json_response(PrefsResponse::unchanged(
+            "manual_memory_ids",
+            "add",
+            Some(memory_id),
+        ));
+    }
+
+    preferences.manual_memory_ids.push(memory_id.clone());
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "manual_memory_ids",
+        "add",
+        Some(memory_id),
+    ))
+}
+
+fn remove_memory(args: MemoryIdArgs) -> Result<()> {
+    let memory_id = validate_memory_id(args.memory_id.as_str())?;
+    let mut preferences = load_preferences()?;
+    let original_len = preferences.manual_memory_ids.len();
+    preferences
+        .manual_memory_ids
+        .retain(|saved| saved != &memory_id);
+
+    if preferences.manual_memory_ids.len() == original_len {
+        return print_json_response(PrefsResponse::unchanged(
+            "manual_memory_ids",
+            "remove",
+            Some(memory_id),
+        ));
+    }
+
+    save_preferences(&preferences)?;
+    print_json_response(PrefsResponse::updated(
+        "manual_memory_ids",
+        "remove",
+        Some(memory_id),
+    ))
+}
+
+fn load_preferences() -> Result<UserPreferences> {
+    preferences::load_user_preferences().context("Failed to load shared TUI preferences")
+}
+
+fn save_preferences(user_preferences: &UserPreferences) -> Result<()> {
+    let normalized = preferences::normalize_user_preferences(user_preferences.clone());
+    preferences::save_user_preferences(&normalized).context("Failed to save shared TUI preferences")
+}
+
+fn validate_memory_id(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("memory id must not be empty");
+    }
+
+    Principal::from_text(trimmed).with_context(|| format!("invalid principal text: {trimmed}"))?;
+    Ok(trimmed.to_string())
+}
+
+fn validate_tag(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("tag must not be empty");
+    }
+
+    Ok(trimmed.to_string())
+}
+
+#[derive(Debug, Serialize)]
+struct ShowPreferences {
+    default_memory_id: Option<String>,
+    saved_tags: Vec<String>,
+    manual_memory_ids: Vec<String>,
+}
+
+impl From<UserPreferences> for ShowPreferences {
+    fn from(value: UserPreferences) -> Self {
+        Self {
+            default_memory_id: value.default_memory_id,
+            saved_tags: value.saved_tags,
+            manual_memory_ids: value.manual_memory_ids,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PrefsResponse<T>
+where
+    T: Serialize,
+{
+    resource: &'static str,
+    action: &'static str,
+    status: &'static str,
+    value: T,
+}
+
+impl<T> PrefsResponse<T>
+where
+    T: Serialize,
+{
+    fn updated(resource: &'static str, action: &'static str, value: T) -> Self {
+        Self {
+            resource,
+            action,
+            status: "updated",
+            value,
+        }
+    }
+
+    fn unchanged(resource: &'static str, action: &'static str, value: T) -> Self {
+        Self {
+            resource,
+            action,
+            status: "unchanged",
+            value,
+        }
+    }
+}
+
+fn print_json_response<T>(response: PrefsResponse<T>) -> Result<()>
+where
+    T: Serialize,
+{
+    let json = serde_json::to_string_pretty(&response)?;
+    println!("{json}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preferences::{
+        DEFAULT_CHAT_MMR_LAMBDA, DEFAULT_CHAT_OVERALL_TOP_K, DEFAULT_CHAT_PER_MEMORY_CAP,
+    };
+
+    #[test]
+    fn validate_memory_id_accepts_principal_text() {
+        let memory_id = validate_memory_id("aaaaa-aa").unwrap();
+        assert_eq!(memory_id, "aaaaa-aa");
+    }
+
+    #[test]
+    fn validate_memory_id_rejects_empty_input() {
+        let error = validate_memory_id("   ").unwrap_err();
+        assert_eq!(error.to_string(), "memory id must not be empty");
+    }
+
+    #[test]
+    fn validate_memory_id_rejects_invalid_principal() {
+        let error = validate_memory_id("not-a-principal").unwrap_err();
+        assert!(error.to_string().contains("invalid principal text"));
+    }
+
+    #[test]
+    fn validate_tag_trims_input() {
+        let tag = validate_tag("  docs  ").unwrap();
+        assert_eq!(tag, "docs");
+    }
+
+    #[test]
+    fn validate_tag_rejects_empty_input() {
+        let error = validate_tag("  ").unwrap_err();
+        assert_eq!(error.to_string(), "tag must not be empty");
+    }
+
+    #[test]
+    fn save_preferences_normalizes_mutated_fields_and_preserves_chat_settings() {
+        let preferences = UserPreferences {
+            default_memory_id: Some("aaaaa-aa".to_string()),
+            saved_tags: vec![" docs ".to_string(), "docs".to_string(), "zeta".to_string()],
+            manual_memory_ids: vec!["bbbbb-bb".to_string(), "bbbbb-bb".to_string()],
+            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
+            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
+            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
+        };
+
+        let normalized = preferences::normalize_user_preferences(preferences);
+
+        assert_eq!(normalized.default_memory_id.as_deref(), Some("aaaaa-aa"));
+        assert_eq!(
+            normalized.saved_tags,
+            vec!["docs".to_string(), "zeta".to_string()]
+        );
+        assert_eq!(normalized.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
+        assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
+        assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
+        assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
+    }
+
+    #[test]
+    fn show_preferences_from_user_preferences_omits_chat_fields() {
+        let serialized = serde_json::to_value(ShowPreferences::from(UserPreferences::default()))
+            .expect("show preferences should serialize");
+
+        assert_eq!(serialized["default_memory_id"], serde_json::Value::Null);
+        assert_eq!(serialized["saved_tags"], serde_json::json!([]));
+        assert_eq!(serialized["manual_memory_ids"], serde_json::json!([]));
+        assert!(serialized.get("chat_overall_top_k").is_none());
+    }
+
+    #[test]
+    fn prefs_response_serializes_with_status_and_value() {
+        let serialized = serde_json::to_value(PrefsResponse::updated(
+            "saved_tags",
+            "add",
+            Some("docs".to_string()),
+        ))
+        .expect("prefs response should serialize");
+
+        assert_eq!(serialized["resource"], "saved_tags");
+        assert_eq!(serialized["action"], "add");
+        assert_eq!(serialized["status"], "updated");
+        assert_eq!(serialized["value"], serde_json::json!("docs"));
+    }
+}

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod insert_service;
 mod ledger;
 pub(crate) mod memory_client_builder;
 mod operation_timeout;
+pub(crate) mod preferences;
 mod prompt_utils;
 #[cfg(feature = "python-bindings")]
 mod python;
@@ -24,7 +25,7 @@ use tracing_subscriber::fmt;
 use crate::{
     agent::AgentFactory,
     cli::Cli,
-    commands::{CommandContext, run_command},
+    commands::{CommandContext, capabilities, prefs, run_command},
 };
 
 pub(crate) const KEYRING_IDENTITY_REQUIRED_MESSAGE: &str =
@@ -61,34 +62,37 @@ pub async fn run() -> Result<()> {
         return tui::run(&cli.global);
     }
 
-    if cli.global.ii
-        && matches!(
-            &cli.command,
-            cli::Command::Create(_) | cli::Command::Balance(_)
-        )
-        && !cfg!(feature = "experimental")
-    {
-        anyhow::bail!(
-            "For security reasons, using a locally hosted origin Internet Identity is not recommended for commands involving asset transfers."
-        );
+    match cli.command {
+        cli::Command::Capabilities(args) => capabilities::handle(args),
+        cli::Command::Prefs(args) => prefs::handle(args),
+        command => {
+            if cli.global.ii
+                && matches!(&command, cli::Command::Create(_) | cli::Command::Balance(_))
+                && !cfg!(feature = "experimental")
+            {
+                anyhow::bail!(
+                    "For security reasons, using a locally hosted origin Internet Identity is not recommended for commands involving asset transfers."
+                );
+            }
+
+            let (agent_factory, identity_path) = if matches!(&command, cli::Command::Login(_)) {
+                let identity_path = Some(resolve_identity_path(&cli.global)?);
+                (
+                    AgentFactory::new(cli.global.ic, String::new()),
+                    identity_path,
+                )
+            } else {
+                build_cli_command_context(&cli.global)?
+            };
+
+            let context = CommandContext {
+                agent_factory,
+                identity_path,
+            };
+
+            run_command(command, context).await
+        }
     }
-
-    let (agent_factory, identity_path) = if matches!(&cli.command, cli::Command::Login(_)) {
-        let identity_path = Some(resolve_identity_path(&cli.global)?);
-        (
-            AgentFactory::new(cli.global.ic, String::new()),
-            identity_path,
-        )
-    } else {
-        build_cli_command_context(&cli.global)?
-    };
-
-    let context = CommandContext {
-        agent_factory,
-        identity_path,
-    };
-
-    run_command(cli.command, context).await
 }
 
 fn validate_tui_cli_args(cli: &Cli) -> Result<()> {
@@ -126,6 +130,12 @@ fn validate_keyring_identity(cli: &Cli) -> Result<()> {
         return Ok(());
     }
     if matches!(&cli.command, cli::Command::Tui(_)) {
+        return Ok(());
+    }
+    if matches!(&cli.command, cli::Command::Capabilities(_)) {
+        return Ok(());
+    }
+    if matches!(&cli.command, cli::Command::Prefs(_)) {
         return Ok(());
     }
     if cli.global.identity.is_some() {
@@ -294,6 +304,32 @@ mod tests {
         let cli = Cli::try_parse_from(["kinic-cli", "--identity", "alice", "tui"]).expect("cli");
 
         validate_keyring_identity(&cli).expect("tui handled by validate_tui_cli_args");
+    }
+
+    #[test]
+    fn validate_keyring_identity_skips_prefs_command_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "prefs", "show"]).expect("cli");
+
+        validate_keyring_identity(&cli).expect("prefs should not require identity");
+    }
+
+    #[test]
+    fn validate_keyring_identity_skips_capabilities_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "capabilities"]).expect("cli");
+
+        validate_keyring_identity(&cli).expect("capabilities should not require identity");
+    }
+
+    #[test]
+    fn cli_parses_prefs_show_without_identity() {
+        let cli = Cli::try_parse_from(["kinic-cli", "prefs", "show"]).expect("cli");
+
+        assert!(matches!(
+            cli.command,
+            cli::Command::Prefs(cli::PrefsArgs {
+                command: cli::PrefsCommand::Show
+            })
+        ));
     }
 }
 

--- a/rust/preferences.rs
+++ b/rust/preferences.rs
@@ -1,0 +1,216 @@
+//! Shared Kinic preferences persisted for both CLI and TUI.
+//! Where: crate-level module used by CLI prefs commands and the TUI runtime.
+//! What: owns the on-disk schema plus normalization and YAML persistence helpers.
+//! Why: avoid coupling CLI preference management to TUI-specific screen and chat-history code.
+
+use serde::{Deserialize, Serialize};
+use tui_kit_host::settings::SettingsError;
+#[cfg(not(test))]
+use tui_kit_host::settings::{load_yaml_or_default, save_yaml};
+
+#[cfg(not(test))]
+const APP_NAMESPACE: &str = "kinic";
+#[cfg(not(test))]
+const SETTINGS_FILE_NAME: &str = "tui.yaml";
+pub const DEFAULT_CHAT_OVERALL_TOP_K: usize = 8;
+pub const DEFAULT_CHAT_PER_MEMORY_CAP: usize = 3;
+pub const DEFAULT_CHAT_MMR_LAMBDA: u8 = 70;
+const CHAT_RESULT_LIMIT_OPTIONS: &[usize] = &[4, 6, 8, 10, 12];
+const CHAT_PER_MEMORY_LIMIT_OPTIONS: &[usize] = &[1, 2, 3, 4];
+const CHAT_DIVERSITY_OPTIONS: &[u8] = &[60, 70, 80, 90];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// The current on-disk schema is intentionally fixed; unsupported legacy shapes fail to decode.
+pub struct UserPreferences {
+    pub default_memory_id: Option<String>,
+    pub saved_tags: Vec<String>,
+    pub manual_memory_ids: Vec<String>,
+    #[serde(default = "default_chat_overall_top_k")]
+    pub chat_overall_top_k: usize,
+    #[serde(default = "default_chat_per_memory_cap")]
+    pub chat_per_memory_cap: usize,
+    #[serde(default = "default_chat_mmr_lambda")]
+    pub chat_mmr_lambda: u8,
+}
+
+impl Default for UserPreferences {
+    fn default() -> Self {
+        Self {
+            default_memory_id: None,
+            saved_tags: Vec::new(),
+            manual_memory_ids: Vec::new(),
+            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
+            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
+            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
+        }
+    }
+}
+
+pub fn default_chat_overall_top_k() -> usize {
+    DEFAULT_CHAT_OVERALL_TOP_K
+}
+
+pub fn default_chat_per_memory_cap() -> usize {
+    DEFAULT_CHAT_PER_MEMORY_CAP
+}
+
+pub fn default_chat_mmr_lambda() -> u8 {
+    DEFAULT_CHAT_MMR_LAMBDA
+}
+
+#[cfg(test)]
+pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
+    Ok(normalize_user_preferences(UserPreferences::default()))
+}
+
+#[cfg(not(test))]
+pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
+    let preferences: UserPreferences = load_yaml_or_default(APP_NAMESPACE, SETTINGS_FILE_NAME)?;
+    Ok(normalize_user_preferences(preferences))
+}
+
+#[cfg(test)]
+pub fn save_user_preferences(_preferences: &UserPreferences) -> Result<(), SettingsError> {
+    Ok(())
+}
+
+#[cfg(not(test))]
+pub fn save_user_preferences(preferences: &UserPreferences) -> Result<(), SettingsError> {
+    save_yaml(
+        APP_NAMESPACE,
+        SETTINGS_FILE_NAME,
+        &normalize_user_preferences(preferences.clone()),
+    )
+}
+
+pub fn normalize_saved_tags(mut tags: Vec<String>) -> Vec<String> {
+    tags = tags
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+pub fn normalize_user_preferences(mut preferences: UserPreferences) -> UserPreferences {
+    preferences.saved_tags = normalize_saved_tags(preferences.saved_tags);
+    preferences.manual_memory_ids = normalize_manual_memory_ids(preferences.manual_memory_ids);
+    preferences.chat_overall_top_k = normalize_chat_overall_top_k(preferences.chat_overall_top_k);
+    preferences.chat_per_memory_cap =
+        normalize_chat_per_memory_cap(preferences.chat_per_memory_cap);
+    preferences.chat_mmr_lambda = normalize_chat_mmr_lambda(preferences.chat_mmr_lambda);
+    preferences
+}
+
+pub fn normalize_chat_overall_top_k(value: usize) -> usize {
+    if CHAT_RESULT_LIMIT_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_OVERALL_TOP_K
+    }
+}
+
+pub fn normalize_chat_per_memory_cap(value: usize) -> usize {
+    if CHAT_PER_MEMORY_LIMIT_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_PER_MEMORY_CAP
+    }
+}
+
+pub fn normalize_chat_mmr_lambda(value: u8) -> u8 {
+    if CHAT_DIVERSITY_OPTIONS.contains(&value) {
+        value
+    } else {
+        DEFAULT_CHAT_MMR_LAMBDA
+    }
+}
+
+pub fn chat_result_limit_options() -> &'static [usize] {
+    CHAT_RESULT_LIMIT_OPTIONS
+}
+
+pub fn chat_per_memory_limit_options() -> &'static [usize] {
+    CHAT_PER_MEMORY_LIMIT_OPTIONS
+}
+
+pub fn chat_diversity_options() -> &'static [u8] {
+    CHAT_DIVERSITY_OPTIONS
+}
+
+pub fn chat_result_limit_display(value: usize) -> String {
+    format!("{value} docs")
+}
+
+pub fn chat_per_memory_limit_display(value: usize) -> String {
+    format!("{value} per memory")
+}
+
+pub fn chat_diversity_display(value: u8) -> String {
+    format!("{:.2}", f32::from(value) / 100.0)
+}
+
+fn normalize_manual_memory_ids(memory_ids: Vec<String>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for memory_id in memory_ids
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        if !unique.iter().any(|existing| existing == &memory_id) {
+            unique.push(memory_id);
+        }
+    }
+    unique
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_preferences_accepts_unknown_fields() {
+        let with_unknown: UserPreferences = serde_yaml::from_str(
+            r#"
+default_memory_id: aaaaa-aa
+saved_tags:
+  - docs
+manual_memory_ids:
+  - bbbbb-bb
+future_setting: true
+"#,
+        )
+        .expect("unknown fields should be ignored");
+
+        assert_eq!(with_unknown.default_memory_id.as_deref(), Some("aaaaa-aa"));
+        assert_eq!(with_unknown.saved_tags, vec!["docs".to_string()]);
+        assert_eq!(with_unknown.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
+    }
+
+    #[test]
+    fn user_preferences_rejects_missing_saved_tags() {
+        let result = serde_yaml::from_str::<UserPreferences>("default_memory_id: aaaaa-aa\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn user_preferences_normalizes_missing_chat_retrieval_fields() {
+        let preferences: UserPreferences = serde_yaml::from_str(
+            r#"
+default_memory_id: aaaaa-aa
+saved_tags:
+  - docs
+manual_memory_ids:
+  - bbbbb-bb
+"#,
+        )
+        .expect("chat retrieval fields should default");
+
+        let normalized = normalize_user_preferences(preferences);
+        assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
+        assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
+        assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
+    }
+}

--- a/rust/tui/mod.rs
+++ b/rust/tui/mod.rs
@@ -19,7 +19,7 @@ mod chat_retrieval;
 mod chat_service;
 mod chat_similarity;
 mod provider;
-mod settings;
+pub(crate) mod settings;
 mod ui_config;
 
 #[cfg(test)]

--- a/rust/tui/provider/mod.rs
+++ b/rust/tui/provider/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use super::adapter;
 use super::bridge::{self, MemorySummary, SearchResultItem};
 use super::chat_prompt::ActiveMemoryContext;
-use super::settings::{self, PreferencesHealth, UserPreferences};
+use super::settings::{self, PreferencesHealth};
 use crate::{
     create_domain::derive_create_cost,
     embedding::fetch_embedding,
@@ -18,6 +18,7 @@ use crate::{
         InsertRequest, parse_embedding_json, validate_insert_request_fields,
         validate_insert_request_for_submit,
     },
+    preferences::{self, UserPreferences},
     tui::TuiAuth,
 };
 use ic_agent::export::Principal;
@@ -365,7 +366,7 @@ impl<'a> DefaultMemorySelection<'a> {
 }
 
 fn saved_tag_selection(preferences: &UserPreferences) -> Vec<String> {
-    settings::normalize_saved_tags(preferences.saved_tags.clone())
+    preferences::normalize_saved_tags(preferences.saved_tags.clone())
 }
 
 fn add_action_label_for_context(context: PickerContext) -> Option<&'static str> {
@@ -450,32 +451,32 @@ fn picker_items_for_context(
                 .unwrap_or_default(),
             _ => Vec::new(),
         },
-        PickerContext::ChatResultLimit => settings::chat_result_limit_options()
+        PickerContext::ChatResultLimit => preferences::chat_result_limit_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_result_limit_display(*value),
+                    preferences::chat_result_limit_display(*value),
                     user_preferences.chat_overall_top_k == *value,
                 )
             })
             .collect(),
-        PickerContext::ChatPerMemoryLimit => settings::chat_per_memory_limit_options()
+        PickerContext::ChatPerMemoryLimit => preferences::chat_per_memory_limit_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_per_memory_limit_display(*value),
+                    preferences::chat_per_memory_limit_display(*value),
                     user_preferences.chat_per_memory_cap == *value,
                 )
             })
             .collect(),
-        PickerContext::ChatDiversity => settings::chat_diversity_options()
+        PickerContext::ChatDiversity => preferences::chat_diversity_options()
             .iter()
             .map(|value| {
                 PickerItem::option(
                     value.to_string(),
-                    settings::chat_diversity_display(*value),
+                    preferences::chat_diversity_display(*value),
                     user_preferences.chat_mmr_lambda == *value,
                 )
             })
@@ -589,7 +590,7 @@ fn reload_preferences_for_apply(
 
     #[cfg(not(test))]
     {
-        settings::load_user_preferences()
+        preferences::load_user_preferences()
     }
 }
 
@@ -601,7 +602,7 @@ fn save_user_preferences_for_apply(
         return Err(tui_kit_host::settings::SettingsError::NoConfigDir);
     }
 
-    settings::save_user_preferences(preferences)
+    preferences::save_user_preferences(preferences)
 }
 
 #[cfg(test)]
@@ -945,7 +946,7 @@ impl KinicProvider {
         let _settings_io_lock = settings_io_lock()
             .lock()
             .expect("settings io lock should be available");
-        let (user_preferences, preferences_health) = match settings::load_user_preferences() {
+        let (user_preferences, preferences_health) = match preferences::load_user_preferences() {
             Ok(preferences) => (preferences, PreferencesHealth::default()),
             Err(error) => (
                 UserPreferences::default(),
@@ -2391,7 +2392,7 @@ impl KinicProvider {
         let mut updated_preferences = self.user_preferences.clone();
         updated_preferences.saved_tags.push(normalized_tag.clone());
         updated_preferences.saved_tags =
-            settings::normalize_saved_tags(updated_preferences.saved_tags);
+            preferences::normalize_saved_tags(updated_preferences.saved_tags);
 
         #[cfg(test)]
         let _settings_io_lock = settings_io_lock()
@@ -2432,7 +2433,7 @@ impl KinicProvider {
             .saved_tags
             .retain(|saved| saved != &normalized_tag);
         updated_preferences.saved_tags =
-            settings::normalize_saved_tags(updated_preferences.saved_tags);
+            preferences::normalize_saved_tags(updated_preferences.saved_tags);
 
         #[cfg(test)]
         let _settings_io_lock = settings_io_lock()
@@ -2707,7 +2708,7 @@ impl KinicProvider {
         if self.user_preferences.chat_overall_top_k == value {
             return CoreEffect::Notify(format!(
                 "Chat result limit already set to {}",
-                settings::chat_result_limit_display(value)
+                preferences::chat_result_limit_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2715,7 +2716,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Chat result limit set to {}",
-                settings::chat_result_limit_display(value)
+                preferences::chat_result_limit_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Chat result limit save failed: {error}")),
         }
@@ -2725,7 +2726,7 @@ impl KinicProvider {
         if self.user_preferences.chat_per_memory_cap == value {
             return CoreEffect::Notify(format!(
                 "Per-memory limit already set to {}",
-                settings::chat_per_memory_limit_display(value)
+                preferences::chat_per_memory_limit_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2733,7 +2734,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Per-memory limit set to {}",
-                settings::chat_per_memory_limit_display(value)
+                preferences::chat_per_memory_limit_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Per-memory limit save failed: {error}")),
         }
@@ -2743,7 +2744,7 @@ impl KinicProvider {
         if self.user_preferences.chat_mmr_lambda == value {
             return CoreEffect::Notify(format!(
                 "Chat diversity already set to {}",
-                settings::chat_diversity_display(value)
+                preferences::chat_diversity_display(value)
             ));
         }
         match self.update_user_preferences(|preferences| {
@@ -2751,7 +2752,7 @@ impl KinicProvider {
         }) {
             Ok(()) => CoreEffect::Notify(format!(
                 "Chat diversity set to {}",
-                settings::chat_diversity_display(value)
+                preferences::chat_diversity_display(value)
             )),
             Err(error) => CoreEffect::Notify(format!("Chat diversity save failed: {error}")),
         }

--- a/rust/tui/settings.rs
+++ b/rust/tui/settings.rs
@@ -16,51 +16,20 @@ use tui_kit_runtime::{
     format_e8s_to_kinic_string_u128,
 };
 
+use crate::preferences::{
+    UserPreferences, chat_diversity_display, chat_per_memory_limit_display,
+    chat_result_limit_display,
+};
 use crate::tui::TuiAuth;
 
 #[cfg(not(test))]
 const APP_NAMESPACE: &str = "kinic";
-#[cfg(not(test))]
-const SETTINGS_FILE_NAME: &str = "tui.yaml";
 #[cfg(not(test))]
 const CHAT_HISTORY_FILE_NAME: &str = "chat-threads.yaml";
 const UNAVAILABLE: &str = "unavailable";
 const NOT_SET: &str = "not set";
 const CHAT_HISTORY_MAX_MESSAGES: usize = 40;
 const CHAT_MESSAGE_MAX_CONTENT_LEN: usize = 4096;
-pub const DEFAULT_CHAT_OVERALL_TOP_K: usize = 8;
-pub const DEFAULT_CHAT_PER_MEMORY_CAP: usize = 3;
-pub const DEFAULT_CHAT_MMR_LAMBDA: u8 = 70;
-const CHAT_RESULT_LIMIT_OPTIONS: &[usize] = &[4, 6, 8, 10, 12];
-const CHAT_PER_MEMORY_LIMIT_OPTIONS: &[usize] = &[1, 2, 3, 4];
-const CHAT_DIVERSITY_OPTIONS: &[u8] = &[60, 70, 80, 90];
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-// The current on-disk schema is intentionally fixed; unsupported legacy shapes fail to decode.
-pub struct UserPreferences {
-    pub default_memory_id: Option<String>,
-    pub saved_tags: Vec<String>,
-    pub manual_memory_ids: Vec<String>,
-    #[serde(default = "default_chat_overall_top_k")]
-    pub chat_overall_top_k: usize,
-    #[serde(default = "default_chat_per_memory_cap")]
-    pub chat_per_memory_cap: usize,
-    #[serde(default = "default_chat_mmr_lambda")]
-    pub chat_mmr_lambda: u8,
-}
-
-impl Default for UserPreferences {
-    fn default() -> Self {
-        Self {
-            default_memory_id: None,
-            saved_tags: Vec::new(),
-            manual_memory_ids: Vec::new(),
-            chat_overall_top_k: DEFAULT_CHAT_OVERALL_TOP_K,
-            chat_per_memory_cap: DEFAULT_CHAT_PER_MEMORY_CAP,
-            chat_mmr_lambda: DEFAULT_CHAT_MMR_LAMBDA,
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PreferencesHealth {
@@ -105,43 +74,6 @@ pub struct StoredChatMessage {
 pub struct ActiveChatThread {
     pub thread_id: String,
     pub messages: Vec<(String, String)>,
-}
-
-pub fn default_chat_overall_top_k() -> usize {
-    DEFAULT_CHAT_OVERALL_TOP_K
-}
-
-pub fn default_chat_per_memory_cap() -> usize {
-    DEFAULT_CHAT_PER_MEMORY_CAP
-}
-
-pub fn default_chat_mmr_lambda() -> u8 {
-    DEFAULT_CHAT_MMR_LAMBDA
-}
-
-#[cfg(test)]
-pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
-    Ok(normalize_user_preferences(UserPreferences::default()))
-}
-
-#[cfg(not(test))]
-pub fn load_user_preferences() -> Result<UserPreferences, SettingsError> {
-    let preferences: UserPreferences = load_yaml_or_default(APP_NAMESPACE, SETTINGS_FILE_NAME)?;
-    Ok(normalize_user_preferences(preferences))
-}
-
-#[cfg(test)]
-pub fn save_user_preferences(_preferences: &UserPreferences) -> Result<(), SettingsError> {
-    Ok(())
-}
-
-#[cfg(not(test))]
-pub fn save_user_preferences(preferences: &UserPreferences) -> Result<(), SettingsError> {
-    save_yaml(
-        APP_NAMESPACE,
-        SETTINGS_FILE_NAME,
-        &normalize_user_preferences(preferences.clone()),
-    )
 }
 
 pub fn current_chat_saved_at() -> u64 {
@@ -779,96 +711,12 @@ fn preferences_status_label(health: &PreferencesHealth) -> String {
     }
 }
 
-pub(crate) fn normalize_saved_tags(mut tags: Vec<String>) -> Vec<String> {
-    tags = tags
-        .into_iter()
-        .map(|tag| tag.trim().to_string())
-        .filter(|tag| !tag.is_empty())
-        .collect();
-    tags.sort();
-    tags.dedup();
-    tags
-}
-
-pub fn normalize_user_preferences(mut preferences: UserPreferences) -> UserPreferences {
-    preferences.saved_tags = normalize_saved_tags(preferences.saved_tags);
-    preferences.manual_memory_ids = normalize_manual_memory_ids(preferences.manual_memory_ids);
-    preferences.chat_overall_top_k = normalize_chat_overall_top_k(preferences.chat_overall_top_k);
-    preferences.chat_per_memory_cap =
-        normalize_chat_per_memory_cap(preferences.chat_per_memory_cap);
-    preferences.chat_mmr_lambda = normalize_chat_mmr_lambda(preferences.chat_mmr_lambda);
-    preferences
-}
-
-pub fn normalize_chat_overall_top_k(value: usize) -> usize {
-    if CHAT_RESULT_LIMIT_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_OVERALL_TOP_K
-    }
-}
-
-pub fn normalize_chat_per_memory_cap(value: usize) -> usize {
-    if CHAT_PER_MEMORY_LIMIT_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_PER_MEMORY_CAP
-    }
-}
-
-pub fn normalize_chat_mmr_lambda(value: u8) -> u8 {
-    if CHAT_DIVERSITY_OPTIONS.contains(&value) {
-        value
-    } else {
-        DEFAULT_CHAT_MMR_LAMBDA
-    }
-}
-
-pub fn chat_result_limit_options() -> &'static [usize] {
-    CHAT_RESULT_LIMIT_OPTIONS
-}
-
-pub fn chat_per_memory_limit_options() -> &'static [usize] {
-    CHAT_PER_MEMORY_LIMIT_OPTIONS
-}
-
-pub fn chat_diversity_options() -> &'static [u8] {
-    CHAT_DIVERSITY_OPTIONS
-}
-
-pub fn chat_result_limit_display(value: usize) -> String {
-    format!("{value} docs")
-}
-
-pub fn chat_per_memory_limit_display(value: usize) -> String {
-    format!("{value} per memory")
-}
-
-pub fn chat_diversity_display(value: u8) -> String {
-    format!("{:.2}", f32::from(value) / 100.0)
-}
-
 fn saved_tags_display(preferences: &UserPreferences) -> String {
     if preferences.saved_tags.is_empty() {
         return NOT_SET.to_string();
     }
 
     preferences.saved_tags.join(", ")
-}
-
-#[cfg_attr(test, allow(dead_code))]
-fn normalize_manual_memory_ids(memory_ids: Vec<String>) -> Vec<String> {
-    let mut unique = Vec::new();
-    for memory_id in memory_ids
-        .into_iter()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-    {
-        if !unique.iter().any(|existing| existing == &memory_id) {
-            unique.push(memory_id);
-        }
-    }
-    unique
 }
 
 #[cfg(test)]

--- a/rust/tui/settings_tests.rs
+++ b/rust/tui/settings_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::preferences::UserPreferences;
 use candid::Nat;
 use tui_kit_runtime::{SETTINGS_ENTRY_DEFAULT_MEMORY_ID, SessionAccountOverview};
 
@@ -52,32 +53,6 @@ fn section_entry_value<'a>(snapshot: &'a SettingsSnapshot, section: &str, id: &s
         .and_then(|current| current.entries.iter().find(|entry| entry.id == id))
         .map(|entry| entry.value.as_str())
         .expect("section entry should exist")
-}
-
-#[test]
-fn user_preferences_accepts_unknown_fields() {
-    let with_unknown: UserPreferences = serde_yaml::from_str(
-        r#"
-default_memory_id: aaaaa-aa
-saved_tags:
-  - docs
-manual_memory_ids:
-  - bbbbb-bb
-future_setting: true
-"#,
-    )
-    .expect("unknown fields should be ignored");
-
-    assert_eq!(with_unknown.default_memory_id.as_deref(), Some("aaaaa-aa"));
-    assert_eq!(with_unknown.saved_tags, vec!["docs".to_string()]);
-    assert_eq!(with_unknown.manual_memory_ids, vec!["bbbbb-bb".to_string()]);
-}
-
-#[test]
-fn user_preferences_rejects_missing_saved_tags() {
-    let result = serde_yaml::from_str::<UserPreferences>("default_memory_id: aaaaa-aa\n");
-
-    assert!(result.is_err());
 }
 
 #[test]
@@ -234,26 +209,6 @@ fn settings_snapshot_projects_default_memory_and_preferences_status() {
             "{name}"
         );
     }
-}
-
-#[test]
-fn user_preferences_normalizes_missing_chat_retrieval_fields() {
-    let preferences: UserPreferences = serde_yaml::from_str(
-        r#"
-default_memory_id: aaaaa-aa
-saved_tags:
-  - docs
-manual_memory_ids:
-  - bbbbb-bb
-"#,
-    )
-    .expect("chat retrieval fields should default");
-
-    let normalized = normalize_user_preferences(preferences);
-
-    assert_eq!(normalized.chat_overall_top_k, DEFAULT_CHAT_OVERALL_TOP_K);
-    assert_eq!(normalized.chat_per_memory_cap, DEFAULT_CHAT_PER_MEMORY_CAP);
-    assert_eq!(normalized.chat_mmr_lambda, DEFAULT_CHAT_MMR_LAMBDA);
 }
 
 #[test]

--- a/tests/kinic_cli_capabilities.rs
+++ b/tests/kinic_cli_capabilities.rs
@@ -1,0 +1,169 @@
+use std::process::Command;
+
+use _lib::cli::Cli;
+use clap::CommandFactory;
+use serde_json::json;
+
+#[test]
+fn capabilities_runs_without_identity_and_returns_json() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(parsed["cli"], "kinic-cli");
+    assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+    assert!(parsed["commands"].is_array());
+}
+
+#[test]
+fn capabilities_describes_prefs_and_tui_contracts() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+
+    let prefs = commands
+        .iter()
+        .find(|entry| entry["name"] == "prefs")
+        .expect("prefs command should be present");
+    assert_eq!(prefs["requires_auth"], false);
+    assert_eq!(prefs["output_mode"], "json");
+    assert!(prefs["subcommands"].is_array());
+    assert!(
+        prefs["subcommands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["name"] == "set-default-memory")
+    );
+
+    let tui = commands
+        .iter()
+        .find(|entry| entry["name"] == "tui")
+        .expect("tui command should be present");
+    assert_eq!(tui["interactive"], true);
+    assert_eq!(tui["output_mode"], "interactive");
+    assert_eq!(tui["auth_modes"], json!(["identity"]));
+}
+
+#[test]
+fn capabilities_describes_major_arguments_for_network_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+
+    let search = commands
+        .iter()
+        .find(|entry| entry["name"] == "search")
+        .expect("search command should be present");
+    assert_eq!(search["auth_modes"], json!(["identity", "ii"]));
+    assert_eq!(
+        search["arguments"],
+        json!([
+            { "name": "memory_id", "required": true, "kind": "principal" },
+            { "name": "query", "required": true, "kind": "string" }
+        ])
+    );
+
+    let insert = commands
+        .iter()
+        .find(|entry| entry["name"] == "insert")
+        .expect("insert command should be present");
+    assert_eq!(
+        insert["arg_groups"],
+        json!([
+            {
+                "id": "insert_input",
+                "required": true,
+                "multiple": false,
+                "members": ["text", "file_path"]
+            }
+        ])
+    );
+
+    let capabilities = commands
+        .iter()
+        .find(|entry| entry["name"] == "capabilities")
+        .expect("capabilities command should be present");
+    assert_eq!(capabilities["requires_auth"], false);
+    assert_eq!(capabilities["output_mode"], "json");
+}
+
+#[test]
+fn capabilities_command_names_match_clap_definition() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+    let capability_names: Vec<&str> = commands
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    let clap_names: Vec<String> = Cli::command()
+        .get_subcommands()
+        .map(|command| command.get_name().to_string())
+        .collect();
+
+    assert_eq!(
+        capability_names,
+        clap_names.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn capabilities_prefs_subcommands_match_clap_definition() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("capabilities")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let commands = parsed["commands"].as_array().unwrap();
+    let prefs = commands
+        .iter()
+        .find(|entry| entry["name"] == "prefs")
+        .expect("prefs command should be present");
+    let capability_names: Vec<&str> = prefs["subcommands"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["name"].as_str().unwrap())
+        .collect();
+    let clap = Cli::command();
+    let clap_prefs = clap
+        .get_subcommands()
+        .find(|command| command.get_name() == "prefs")
+        .expect("prefs should exist in clap");
+    let clap_names: Vec<String> = clap_prefs
+        .get_subcommands()
+        .map(|command| command.get_name().to_string())
+        .collect();
+
+    assert_eq!(
+        capability_names,
+        clap_names.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}

--- a/tests/kinic_cli_prefs.rs
+++ b/tests/kinic_cli_prefs.rs
@@ -1,0 +1,244 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::json;
+
+fn temp_config_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("kinic-cli-prefs-{name}-{nanos}"));
+    fs::create_dir_all(&path).expect("temp config dir should be created");
+    path
+}
+
+fn app_config_root(home_dir: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home_dir.join("Library").join("Application Support")
+    } else {
+        home_dir.join(".config")
+    }
+}
+
+fn prefs_command(config_dir: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kinic-cli"));
+    command.env("HOME", config_dir);
+    command.env("XDG_CONFIG_HOME", app_config_root(config_dir));
+    command
+}
+
+fn read_prefs_yaml(config_dir: &Path) -> String {
+    fs::read_to_string(app_config_root(config_dir).join("kinic").join("tui.yaml"))
+        .expect("prefs yaml should exist after mutation")
+}
+
+#[test]
+fn prefs_show_runs_without_identity() {
+    let config_dir = temp_config_dir("show");
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "show"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "default_memory_id": null,
+            "saved_tags": [],
+            "manual_memory_ids": [],
+        })
+    );
+}
+
+#[test]
+fn prefs_mutations_update_shared_yaml_and_preserve_chat_fields() {
+    let config_dir = temp_config_dir("mutations");
+    let kinic_dir = app_config_root(&config_dir).join("kinic");
+    fs::create_dir_all(&kinic_dir).unwrap();
+    fs::write(
+        kinic_dir.join("tui.yaml"),
+        concat!(
+            "default_memory_id: yta6k-5x777-77774-aaaaa-cai\n",
+            "saved_tags:\n",
+            "  - keep\n",
+            "manual_memory_ids:\n",
+            "  - yta6k-5x777-77774-aaaaa-cai\n",
+            "chat_overall_top_k: 10\n",
+            "chat_per_memory_cap: 4\n",
+            "chat_mmr_lambda: 80\n"
+        ),
+    )
+    .unwrap();
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "set-default-memory", "--memory-id", "aaaaa-aa"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "default_memory_id",
+            "action": "set",
+            "status": "updated",
+            "value": "aaaaa-aa"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "add-tag", "--tag", "  docs  "])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "saved_tags",
+            "action": "add",
+            "status": "updated",
+            "value": "docs"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args([
+            "prefs",
+            "add-memory",
+            "--memory-id",
+            "ryjl3-tyaaa-aaaaa-aaaba-cai",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "manual_memory_ids",
+            "action": "add",
+            "status": "updated",
+            "value": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+        })
+    );
+
+    let yaml = read_prefs_yaml(&config_dir);
+    assert!(yaml.contains("default_memory_id: aaaaa-aa"));
+    assert!(yaml.contains("- docs"));
+    assert!(yaml.contains("- keep"));
+    assert!(yaml.contains("- ryjl3-tyaaa-aaaaa-aaaba-cai"));
+    assert!(yaml.contains("chat_overall_top_k: 10"));
+    assert!(yaml.contains("chat_per_memory_cap: 4"));
+    assert!(yaml.contains("chat_mmr_lambda: 80"));
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "show"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "default_memory_id": "aaaaa-aa",
+            "saved_tags": ["docs", "keep"],
+            "manual_memory_ids": [
+                "yta6k-5x777-77774-aaaaa-cai",
+                "ryjl3-tyaaa-aaaaa-aaaba-cai"
+            ],
+        })
+    );
+}
+
+#[test]
+fn prefs_remove_commands_report_unchanged_when_entry_is_missing() {
+    let config_dir = temp_config_dir("remove-missing");
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "remove-tag", "--tag", "docs"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "saved_tags",
+            "action": "remove",
+            "status": "unchanged",
+            "value": "docs"
+        })
+    );
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "remove-memory", "--memory-id", "aaaaa-aa"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "manual_memory_ids",
+            "action": "remove",
+            "status": "unchanged",
+            "value": "aaaaa-aa"
+        })
+    );
+}
+
+#[test]
+fn prefs_clear_default_memory_updates_yaml() {
+    let config_dir = temp_config_dir("clear-default");
+    let kinic_dir = app_config_root(&config_dir).join("kinic");
+    fs::create_dir_all(&kinic_dir).unwrap();
+    fs::write(
+        kinic_dir.join("tui.yaml"),
+        concat!(
+            "default_memory_id: aaaaa-aa\n",
+            "saved_tags: []\n",
+            "manual_memory_ids: []\n"
+        ),
+    )
+    .unwrap();
+
+    let output = prefs_command(&config_dir)
+        .args(["prefs", "clear-default-memory"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed,
+        json!({
+            "resource": "default_memory_id",
+            "action": "clear",
+            "status": "updated",
+            "value": null
+        })
+    );
+    let yaml = read_prefs_yaml(&config_dir);
+    assert!(!yaml.contains("default_memory_id: aaaaa-aa"));
+    assert!(yaml.contains("saved_tags: []"));
+    assert!(yaml.contains("manual_memory_ids: []"));
+}

--- a/tests/kinic_cli_tui.rs
+++ b/tests/kinic_cli_tui.rs
@@ -1,6 +1,64 @@
 use std::process::Command;
 
 #[test]
+fn top_level_help_mentions_agent_entrypoints_and_auth_modes() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout
+            .contains("Network commands require --identity <NAME> or --ii unless noted otherwise.")
+    );
+    assert!(stdout.contains("kinic-cli capabilities"));
+    assert!(stdout.contains("kinic-cli prefs show"));
+    assert!(stdout.contains("capabilities and prefs commands return JSON."));
+}
+
+#[test]
+fn prefs_help_mentions_json_contract_and_examples() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("All prefs commands return JSON."));
+    assert!(stdout.contains("show -> {\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+    assert!(stdout.contains("kinic-cli prefs set-default-memory --memory-id"));
+}
+
+#[test]
+fn prefs_show_help_mentions_return_shape() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "show", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Returns JSON."));
+    assert!(stdout.contains("{\"default_memory_id\": string|null, \"saved_tags\": string[], \"manual_memory_ids\": string[]}"));
+}
+
+#[test]
+fn prefs_mutation_help_mentions_status_shape() {
+    let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
+        .args(["prefs", "add-tag", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Returns JSON."));
+    assert!(stdout.contains("{\"resource\": \"saved_tags\", \"action\": \"add\", \"status\": \"updated\"|\"unchanged\", \"value\": string}"));
+}
+
+#[test]
 fn tui_help_mentions_global_identity_requirement() {
     let output = Command::new(env!("CARGO_BIN_EXE_kinic-cli"))
         .args(["tui", "--help"])
@@ -9,7 +67,8 @@ fn tui_help_mentions_global_identity_requirement() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("requires global --identity"));
+    assert!(stdout.contains("Requires global --identity."));
+    assert!(stdout.contains("--ii is not supported."));
     assert!(stdout.contains("kinic-cli --identity <IDENTITY> tui"));
 }
 

--- a/tui/crates/tui-kit-host/src/lib.rs
+++ b/tui/crates/tui-kit-host/src/lib.rs
@@ -20,11 +20,14 @@ use tui_kit_runtime::{
 pub const DEFAULT_TAB_IDS: [&str; 4] = ["tab-1", "tab-2", "tab-3", "tab-4"];
 
 /// Host-level normalized input event used by app loops.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HostInputEvent {
-    pub key_event: KeyEvent,
-    pub code: KeyCode,
-    pub modifiers: KeyModifiers,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostInputEvent {
+    Key {
+        key_event: KeyEvent,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+    },
+    Paste(String),
 }
 
 /// Poll and normalize crossterm events for host loops.
@@ -37,11 +40,12 @@ pub fn poll_host_input(timeout: Duration) -> std::io::Result<Option<HostInputEve
 
 fn normalize_host_input_event(event: Event) -> Option<HostInputEvent> {
     match event {
-        Event::Key(key) if key.kind == KeyEventKind::Press => Some(HostInputEvent {
+        Event::Key(key) if key.kind == KeyEventKind::Press => Some(HostInputEvent::Key {
             key_event: key,
             code: key.code,
             modifiers: key.modifiers,
         }),
+        Event::Paste(text) => Some(HostInputEvent::Paste(text)),
         _ => None,
     }
 }

--- a/tui/crates/tui-kit-host/src/lib_tests.rs
+++ b/tui/crates/tui-kit-host/src/lib_tests.rs
@@ -27,6 +27,14 @@ mod key_mapping {
 
         assert_eq!(normalize_host_input_event(key_event), None);
     }
+
+    #[test]
+    fn normalize_host_input_event_preserves_paste_payload() {
+        assert_eq!(
+            normalize_host_input_event(Event::Paste("a\nb".to_string())),
+            Some(HostInputEvent::Paste("a\nb".to_string()))
+        );
+    }
 }
 
 mod tab_resolution {

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -159,7 +159,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             terminal.draw(|frame| {
                 let focus = ui_focus_from_pane(state.focus);
                 let insert_file_path_display = insert_file_path_display(&state);
-                let visible_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+                let visible_chat_input = chat_input_display_value(&textareas.chat_input);
                 let ui = TuiKitUi::new(&theme)
                     .ui_config(ui_config())
                     .ui_summaries(&state.list_items)
@@ -762,6 +762,11 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
         textarea.input(textarea_input_from_key_event(*key_event));
         sync_state_from_textareas(state, textareas);
         if target == ActiveTextarea::ChatInput {
+            sync_chat_textarea_from_state(
+                &mut textareas.chat_input,
+                state.chat_input.as_str(),
+                true,
+            );
             sync_chat_command_selection(textareas, state.chat_input.as_str());
         }
         return Ok(true);
@@ -786,7 +791,8 @@ fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
     hooks: &mut H,
     textareas: &mut FormTextareas,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    state.chat_input = normalize_chat_input_lines(state.chat_input.as_str());
+    // Submit and slash-command matching operate on the normalized single-line payload.
+    state.chat_input = chat_input_submit_value(state.chat_input.as_str());
     sync_chat_command_selection(textareas, state.chat_input.as_str());
     if let Some(command_action) =
         selected_slash_command_action(state.chat_input.as_str(), textareas.chat_command_selected)
@@ -994,7 +1000,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str());
+    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str(), false);
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1008,11 +1014,16 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
 }
 
-fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
-    flatten_chat_input_for_display(textarea.lines().join("\n").as_str())
+// Chat input is rendered and edited as a true single-line widget.
+fn chat_input_display_value(textarea: &TextArea<'static>) -> String {
+    textarea.lines().join("\n")
 }
 
-fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
+fn chat_input_submit_value(value: &str) -> String {
+    normalize_chat_input_lines(value)
+}
+
+fn chat_input_display_cursor_col(textarea: &TextArea<'static>) -> usize {
     let lines = textarea.lines();
     let last_row = lines.len().saturating_sub(1);
     let (cursor_row, cursor_col) = textarea.cursor();
@@ -1039,18 +1050,24 @@ fn chat_input_cursor(
     if active != Some(ActiveTextarea::ChatInput) {
         return None;
     }
-    Some((0, normalized_chat_cursor_col(textarea)))
+    Some((0, textarea.cursor().1))
 }
 
-fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str) {
-    // Chat input remains a single-line UI, but the widget may still hold raw pasted
-    // newlines or trailing spaces while editing. Only rebuild when the normalized
-    // text actually diverges so equivalent edits keep the cursor stable.
-    if normalized_chat_textarea_value(textarea) == value {
+fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str, preserve_cursor: bool) {
+    // Rebuild chat input from its flattened single-line form so pasted multiline
+    // content cannot leave hidden rows behind inside the widget.
+    let single_line_value = flatten_chat_input_for_display(value);
+    if textarea.lines().join("\n") == single_line_value {
         return;
     }
-    sync_textarea_from_string(textarea, value);
-    textarea.move_cursor(CursorMove::End);
+    let cursor_col = if preserve_cursor {
+        chat_input_display_cursor_col(textarea).min(single_line_value.chars().count())
+    } else {
+        single_line_value.chars().count()
+    }
+    .min(u16::MAX as usize) as u16;
+    sync_textarea_from_string(textarea, single_line_value.as_str());
+    textarea.move_cursor(CursorMove::Jump(0, cursor_col));
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
@@ -1072,7 +1089,8 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let display_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+    let display_chat_input =
+        flatten_chat_input_for_display(textareas.chat_input.lines().join("\n").as_str());
     if state.chat_input != display_chat_input {
         state.chat_input = display_chat_input;
     }

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -1,7 +1,7 @@
 #[path = "form_tab_flow.rs"]
 mod form_tab_flow;
 
-use ratatui_textarea::{CursorMove, Input as TextAreaInput, Key as TextAreaKey, TextArea};
+use ratatui_textarea::{Input as TextAreaInput, Key as TextAreaKey, TextArea};
 use std::{io, time::Duration};
 use tui_kit_render::theme::Theme;
 use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
@@ -71,10 +71,37 @@ enum ActiveTextarea {
     ChatInput,
 }
 
+// Memories chat uses a dedicated single-line model so chat shortcuts and paste
+// behavior stay independent from multiline textarea defaults.
+#[derive(Default)]
+struct ChatInputState {
+    value: String,
+    cursor_col: usize,
+}
+
+impl ChatInputState {
+    #[cfg(test)]
+    fn lines(&self) -> Vec<String> {
+        vec![self.value.clone()]
+    }
+
+    #[cfg(test)]
+    fn cursor(&self) -> (usize, usize) {
+        (0, self.cursor_col)
+    }
+
+    #[cfg(test)]
+    fn input(&mut self, input: TextAreaInput) {
+        if let Some(action) = chat_edit_from_textarea_input(input) {
+            apply_chat_edit(self, action);
+        }
+    }
+}
+
 struct FormTextareas {
     create_description: TextArea<'static>,
     insert_text: TextArea<'static>,
-    chat_input: TextArea<'static>,
+    chat_input: ChatInputState,
     chat_command_selected: usize,
 }
 
@@ -83,7 +110,7 @@ impl Default for FormTextareas {
         Self {
             create_description: textarea_from_text(""),
             insert_text: textarea_from_text(""),
-            chat_input: textarea_from_text(""),
+            chat_input: ChatInputState::default(),
             chat_command_selected: 0,
         }
     }
@@ -250,176 +277,201 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             let Some(input) = poll_host_input(poll_duration)? else {
                 continue;
             };
-            let HostInputEvent {
-                key_event,
-                code,
-                modifiers,
-            } = input;
-
-            match handle_overlay_input(provider, &mut state, show_settings, code, modifiers) {
-                OverlayInputResult::NotHandled => {}
-                OverlayInputResult::Consumed => continue,
-                OverlayInputResult::CloseSettings => {
-                    show_settings = false;
-                    continue;
-                }
-                OverlayInputResult::DispatchError(error) => {
-                    state.status_message = Some(error);
-                    continue;
-                }
-                OverlayInputResult::ApplyEffects(effects) => {
-                    hooks.on_effects(provider, &mut state, &effects);
-                    execute_effects_to_status(&mut state, effects);
+            if matches!(input, HostInputEvent::Paste(_))
+                && handle_textarea_input(provider, &mut state, hooks, &mut textareas, &input)?
+            {
+                continue;
+            }
+            if let HostInputEvent::Paste(text) = &input {
+                if handle_paste_input(provider, &mut state, hooks, text.as_str())? {
                     continue;
                 }
             }
+            let (_key_event, code, modifiers) = match &input {
+                HostInputEvent::Key {
+                    key_event,
+                    code,
+                    modifiers,
+                } => (Some(*key_event), Some(*code), Some(*modifiers)),
+                HostInputEvent::Paste(_) => (None, None, None),
+            };
 
-            if handle_textarea_input(provider, &mut state, hooks, &mut textareas, &key_event)? {
+            if let (Some(code), Some(modifiers)) = (code, modifiers) {
+                match handle_overlay_input(provider, &mut state, show_settings, code, modifiers) {
+                    OverlayInputResult::NotHandled => {}
+                    OverlayInputResult::Consumed => continue,
+                    OverlayInputResult::CloseSettings => {
+                        show_settings = false;
+                        continue;
+                    }
+                    OverlayInputResult::DispatchError(error) => {
+                        state.status_message = Some(error);
+                        continue;
+                    }
+                    OverlayInputResult::ApplyEffects(effects) => {
+                        hooks.on_effects(provider, &mut state, &effects);
+                        execute_effects_to_status(&mut state, effects);
+                        continue;
+                    }
+                }
+            }
+
+            if handle_textarea_input(provider, &mut state, hooks, &mut textareas, &input)? {
                 continue;
             }
 
-            match global_command_for_key(
-                code,
-                modifiers,
-                state.focus,
-                state.current_tab_id.as_str(),
-                show_help,
-                show_settings,
-                state.query.is_empty(),
-            ) {
-                HostGlobalCommand::None => {}
-                HostGlobalCommand::CloseHelp => {
-                    show_help = false;
-                    continue;
-                }
-                HostGlobalCommand::CloseSettings => {
-                    show_settings = false;
-                    continue;
-                }
-                HostGlobalCommand::CloseChat => {
-                    if let Err(error) =
-                        dispatch_with_effects(provider, &mut state, hooks, &CoreAction::ToggleChat)
-                    {
-                        state.status_message = Some(error);
+            if let (Some(code), Some(modifiers)) = (code, modifiers) {
+                match global_command_for_key(
+                    code,
+                    modifiers,
+                    state.focus,
+                    state.current_tab_id.as_str(),
+                    show_help,
+                    show_settings,
+                    state.query.is_empty(),
+                ) {
+                    HostGlobalCommand::None => {}
+                    HostGlobalCommand::CloseHelp => {
+                        show_help = false;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::BackToTabs => {
-                    state.focus = PaneFocus::Tabs;
-                    continue;
-                }
-                HostGlobalCommand::BackFromFormToTabs => {
-                    state.focus = PaneFocus::Tabs;
-                    continue;
-                }
-                HostGlobalCommand::BackToMemoriesTab => {
-                    if let Err(error) =
-                        switch_to_tab(provider, &mut state, hooks, KINIC_MEMORIES_TAB_ID)
-                    {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::CloseSettings => {
+                        show_settings = false;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::OpenCreateTab => {
-                    open_form_tab(provider, &mut state, hooks, KINIC_CREATE_TAB_ID, true);
-                    continue;
-                }
-                HostGlobalCommand::ToggleHelp => {
-                    show_help = true;
-                    continue;
-                }
-                HostGlobalCommand::ToggleChat => {
-                    if let Err(error) =
-                        dispatch_with_effects(provider, &mut state, hooks, &CoreAction::ToggleChat)
-                    {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::CloseChat => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleChat,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::ToggleSettings => {
-                    match dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::ToggleSettings,
-                    ) {
-                        Ok(()) => show_settings = true,
-                        Err(error) => state.status_message = Some(error),
+                    HostGlobalCommand::BackToTabs => {
+                        state.focus = PaneFocus::Tabs;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::SetDefaultFromSelection => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::SetDefaultMemoryFromSelection,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::BackFromFormToTabs => {
+                        state.focus = PaneFocus::Tabs;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::OpenRenameMemory => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::OpenRenameMemory,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::BackToMemoriesTab => {
+                        if let Err(error) =
+                            switch_to_tab(provider, &mut state, hooks, KINIC_MEMORIES_TAB_ID)
+                        {
+                            state.status_message = Some(error);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::BackFromContent => {
-                    state.focus = PaneFocus::Items;
-                    continue;
-                }
-                HostGlobalCommand::BackFromItems => {
-                    state.focus = PaneFocus::Search;
-                    continue;
-                }
-                HostGlobalCommand::RefreshCurrentView => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::RefreshCurrentView,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::OpenCreateTab => {
+                        open_form_tab(provider, &mut state, hooks, KINIC_CREATE_TAB_ID, true);
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::ClearQuery => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::SetQuery(String::new()),
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::ToggleHelp => {
+                        show_help = true;
+                        continue;
                     }
-                    continue;
+                    HostGlobalCommand::ToggleChat => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleChat,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::ToggleSettings => {
+                        match dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleSettings,
+                        ) {
+                            Ok(()) => show_settings = true,
+                            Err(error) => state.status_message = Some(error),
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::SetDefaultFromSelection => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::SetDefaultMemoryFromSelection,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::OpenRenameMemory => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::OpenRenameMemory,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::BackFromContent => {
+                        state.focus = PaneFocus::Items;
+                        continue;
+                    }
+                    HostGlobalCommand::BackFromItems => {
+                        state.focus = PaneFocus::Search;
+                        continue;
+                    }
+                    HostGlobalCommand::RefreshCurrentView => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::RefreshCurrentView,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::ClearQuery => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::SetQuery(String::new()),
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::Quit => break Ok(()),
                 }
-                HostGlobalCommand::Quit => break Ok(()),
             }
 
-            let action = form_tab_action_from_key(code, &mut state).or_else(|| {
-                if code == crossterm::event::KeyCode::Enter {
-                    if let Some(action) = selected_settings_row_behavior(&state)
-                        .and_then(|behavior| behavior.enter_action)
-                    {
-                        return Some(action);
+            let action = code.and_then(|code| {
+                form_tab_action_from_key(code, &mut state).or_else(|| {
+                    if code == crossterm::event::KeyCode::Enter {
+                        if let Some(action) = selected_settings_row_behavior(&state)
+                            .and_then(|behavior| behavior.enter_action)
+                        {
+                            return Some(action);
+                        }
                     }
-                }
-                action_from_keycode(code, state.focus, state.current_tab_id.as_str()).and_then(
-                    |a| {
-                        resolve_tab_action_with_current(
-                            a,
-                            tab_ids,
-                            Some(state.current_tab_id.as_str()),
-                        )
-                    },
-                )
+                    action_from_keycode(code, state.focus, state.current_tab_id.as_str()).and_then(
+                        |a| {
+                            resolve_tab_action_with_current(
+                                a,
+                                tab_ids,
+                                Some(state.current_tab_id.as_str()),
+                            )
+                        },
+                    )
+                })
             });
             let mut handled = false;
 
@@ -471,17 +523,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                     inspector_scroll = 0;
                 }
             }
-            if !handled
-                && hooks.on_unhandled_input(
-                    provider,
-                    &mut state,
-                    HostInputEvent {
-                        key_event,
-                        code,
-                        modifiers,
-                    },
-                )
-            {
+            if !handled && hooks.on_unhandled_input(provider, &mut state, input) {
                 continue;
             }
         }
@@ -561,7 +603,7 @@ fn build_ui<'a>(
     theme: &'a Theme,
     cfg: &RuntimeLoopConfig,
     state: &'a CoreState,
-    textareas: &FormTextareas,
+    textareas: &'a FormTextareas,
     list_scroll_offset: usize,
     inspector_scroll: usize,
     show_help: bool,
@@ -633,7 +675,7 @@ fn build_ui<'a>(
         .filtered_context_indices(&[])
         .candidates(&[])
         .chat_messages(&state.chat_messages)
-        .chat_input(&state.chat_input)
+        .chat_input(&textareas.chat_input.value)
         .chat_input_cursor(chat_input_cursor(
             active_textarea(state),
             &textareas.chat_input,
@@ -742,18 +784,28 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
     state: &mut CoreState,
     hooks: &mut H,
     textareas: &mut FormTextareas,
-    key_event: &crossterm::event::KeyEvent,
+    input: &HostInputEvent,
 ) -> Result<bool, Box<dyn std::error::Error>> {
+    if let Some(handled) = handle_chat_input_event(provider, state, hooks, textareas, input)? {
+        return Ok(handled);
+    }
+
     let Some(target) = active_textarea(state) else {
         return Ok(false);
     };
-    if target == ActiveTextarea::ChatInput
-        && handle_chat_command_navigation(state, textareas, key_event)
-    {
-        return Ok(true);
-    }
     let textarea = textarea_mut(textareas, target);
-    let action = textarea_navigation_action(target, key_event, key_event.code, textarea);
+    let HostInputEvent::Key {
+        key_event, code, ..
+    } = input
+    else {
+        textarea.insert_str(match input {
+            HostInputEvent::Paste(text) => text.as_str(),
+            HostInputEvent::Key { .. } => "",
+        });
+        sync_state_from_textareas(state, textareas);
+        return Ok(true);
+    };
+    let action = textarea_navigation_action(target, key_event, *code, textarea);
 
     let Some(action) = action else {
         if key_event.code == crossterm::event::KeyCode::Esc {
@@ -761,20 +813,8 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
         }
         textarea.input(textarea_input_from_key_event(*key_event));
         sync_state_from_textareas(state, textareas);
-        if target == ActiveTextarea::ChatInput {
-            sync_chat_textarea_from_state(
-                &mut textareas.chat_input,
-                state.chat_input.as_str(),
-                true,
-            );
-            sync_chat_command_selection(textareas, state.chat_input.as_str());
-        }
         return Ok(true);
     };
-
-    if target == ActiveTextarea::ChatInput && action == CoreAction::ChatSubmit {
-        return handle_chat_submit_or_command(provider, state, hooks, textareas);
-    }
 
     match dispatch_with_effects(provider, state, hooks, &action) {
         Ok(()) => Ok(true),
@@ -783,6 +823,82 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
             Ok(true)
         }
     }
+}
+
+fn handle_chat_input_event<P: DataProvider, H: RuntimeLoopHooks<P>>(
+    provider: &mut P,
+    state: &mut CoreState,
+    hooks: &mut H,
+    textareas: &mut FormTextareas,
+    input: &HostInputEvent,
+) -> Result<Option<bool>, Box<dyn std::error::Error>> {
+    if !chat_input_active(state) {
+        return Ok(None);
+    }
+
+    match input {
+        HostInputEvent::Paste(text) => {
+            insert_chat_text(
+                &mut textareas.chat_input,
+                flatten_chat_input_for_display(text).as_str(),
+            );
+            sync_state_from_chat_input(state, textareas);
+            Ok(Some(true))
+        }
+        HostInputEvent::Key {
+            key_event,
+            code,
+            modifiers,
+        } => {
+            if handle_chat_command_navigation(state, textareas, *code) {
+                return Ok(Some(true));
+            }
+            if let Some(action) = chat_input_action(*key_event, *code, *modifiers) {
+                return match action {
+                    ChatInputAction::Edit(edit) => {
+                        apply_chat_edit(&mut textareas.chat_input, edit);
+                        sync_state_from_chat_input(state, textareas);
+                        Ok(Some(true))
+                    }
+                    ChatInputAction::Submit => {
+                        handle_chat_submit_or_command(provider, state, hooks, textareas).map(Some)
+                    }
+                    ChatInputAction::Dispatch(core_action) => {
+                        match dispatch_with_effects(provider, state, hooks, &core_action) {
+                            Ok(()) => Ok(Some(true)),
+                            Err(error) => {
+                                state.status_message = Some(error);
+                                Ok(Some(true))
+                            }
+                        }
+                    }
+                    ChatInputAction::Passthrough => Ok(Some(false)),
+                };
+            }
+            Ok(Some(false))
+        }
+    }
+}
+
+fn handle_paste_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
+    provider: &mut P,
+    state: &mut CoreState,
+    hooks: &mut H,
+    text: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let normalized = flatten_single_line_paste(text);
+    if normalized.is_empty() {
+        return Ok(false);
+    }
+
+    if let Some(actions) = paste_actions_for_state(state, normalized.as_str()) {
+        for action in actions {
+            dispatch_with_effects(provider, state, hooks, &action).map_err(io::Error::other)?;
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
@@ -826,13 +942,13 @@ fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
 fn handle_chat_command_navigation(
     state: &CoreState,
     textareas: &mut FormTextareas,
-    key_event: &crossterm::event::KeyEvent,
+    code: crossterm::event::KeyCode,
 ) -> bool {
     let matches = matching_slash_commands(state.chat_input.as_str());
     if matches.is_empty() {
         return false;
     }
-    match key_event.code {
+    match code {
         crossterm::event::KeyCode::Up => {
             if textareas.chat_command_selected == 0 {
                 textareas.chat_command_selected = matches.len().saturating_sub(1);
@@ -848,6 +964,103 @@ fn handle_chat_command_navigation(
         }
         _ => false,
     }
+}
+
+fn paste_actions_for_state(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    if state.access_control.open {
+        return paste_actions_for_access_control(state, text);
+    }
+    if state.add_memory.open {
+        return nonempty_actions(char_input_actions(text, CoreAction::AddMemoryInput));
+    }
+    if state.rename_memory.form.open {
+        return paste_actions_for_rename(state, text);
+    }
+    if state.transfer_modal.open {
+        return paste_actions_for_transfer(state, text);
+    }
+    if let PickerState::Input { .. } = &state.picker {
+        return nonempty_actions(char_input_actions(text, CoreAction::PickerInput));
+    }
+    if form_tab_flow::is_form_input_mode(state) && active_textarea(state).is_none() {
+        return nonempty_actions(form_paste_actions(state, text));
+    }
+    if state.focus == PaneFocus::Search {
+        return nonempty_actions(char_input_actions(text, CoreAction::SearchInput));
+    }
+
+    None
+}
+
+fn paste_actions_for_access_control(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::{AccessControlFocus, AccessControlMode};
+
+    if state.access_control.mode == AccessControlMode::Add
+        && state.access_control.focus == AccessControlFocus::Principal
+    {
+        return Some(char_input_actions(text, CoreAction::AccessInput));
+    }
+
+    None
+}
+
+fn paste_actions_for_transfer(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::{TransferModalFocus, TransferModalMode};
+
+    if state.transfer_modal.mode != TransferModalMode::Edit {
+        return None;
+    }
+
+    match state.transfer_modal.focus {
+        TransferModalFocus::Principal | TransferModalFocus::Amount => {
+            Some(char_input_actions(text, CoreAction::TransferInput))
+        }
+        TransferModalFocus::Max | TransferModalFocus::Submit => None,
+    }
+}
+
+fn paste_actions_for_rename(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::RenameModalFocus;
+
+    if state.rename_memory.focus == RenameModalFocus::Name {
+        return nonempty_actions(char_input_actions(text, CoreAction::RenameMemoryInput));
+    }
+
+    None
+}
+
+fn form_paste_actions(state: &CoreState, text: &str) -> Vec<CoreAction> {
+    let mut state_for_actions = state.clone();
+    text.chars()
+        .filter_map(|c| {
+            form_tab_flow::form_tab_action_from_key(
+                crossterm::event::KeyCode::Char(c),
+                &mut state_for_actions,
+            )
+        })
+        .collect()
+}
+
+fn char_input_actions(text: &str, action: impl Fn(char) -> CoreAction) -> Vec<CoreAction> {
+    text.chars().map(action).collect()
+}
+
+fn flatten_single_line_paste(text: &str) -> String {
+    canonicalize_paste_line_endings(text)
+        .lines()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn canonicalize_paste_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn nonempty_actions(actions: Vec<CoreAction>) -> Option<Vec<CoreAction>> {
+    if actions.is_empty() {
+        return None;
+    }
+    Some(actions)
 }
 
 fn sync_chat_command_selection(textareas: &mut FormTextareas, input: &str) {
@@ -874,15 +1087,166 @@ fn chat_command_selection(state: &CoreState, textareas: &FormTextareas) -> Optio
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChatEdit {
+    MoveLeft,
+    MoveRight,
+    MoveHome,
+    MoveEnd,
+    Backspace,
+    Delete,
+    InsertChar(char),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ChatInputAction {
+    Edit(ChatEdit),
+    Submit,
+    Dispatch(CoreAction),
+    Passthrough,
+}
+
+#[cfg(test)]
+fn chat_edit_from_textarea_input(input: TextAreaInput) -> Option<ChatEdit> {
+    match input.key {
+        TextAreaKey::Char(c) if !input.ctrl && !input.alt => Some(ChatEdit::InsertChar(c)),
+        TextAreaKey::Left => Some(ChatEdit::MoveLeft),
+        TextAreaKey::Right => Some(ChatEdit::MoveRight),
+        TextAreaKey::Home => Some(ChatEdit::MoveHome),
+        TextAreaKey::End => Some(ChatEdit::MoveEnd),
+        TextAreaKey::Backspace => Some(ChatEdit::Backspace),
+        TextAreaKey::Delete => Some(ChatEdit::Delete),
+        _ => None,
+    }
+}
+
+fn chat_input_action(
+    _key_event: crossterm::event::KeyEvent,
+    code: crossterm::event::KeyCode,
+    modifiers: crossterm::event::KeyModifiers,
+) -> Option<ChatInputAction> {
+    match (code, modifiers) {
+        (crossterm::event::KeyCode::Tab, _) => {
+            Some(ChatInputAction::Dispatch(CoreAction::FocusNext))
+        }
+        (crossterm::event::KeyCode::BackTab, _) => {
+            Some(ChatInputAction::Dispatch(CoreAction::FocusPrev))
+        }
+        (crossterm::event::KeyCode::Enter, _) => Some(ChatInputAction::Submit),
+        (crossterm::event::KeyCode::Left, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+        }
+        (crossterm::event::KeyCode::Right, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+        }
+        (crossterm::event::KeyCode::PageUp, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::PageDown, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::Home, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+        {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::End, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+        {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::Up, _) | (crossterm::event::KeyCode::Down, _) => {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::Esc, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::Left, _) => Some(ChatInputAction::Edit(ChatEdit::MoveLeft)),
+        (crossterm::event::KeyCode::Right, _) => Some(ChatInputAction::Edit(ChatEdit::MoveRight)),
+        (crossterm::event::KeyCode::Home, _) => Some(ChatInputAction::Edit(ChatEdit::MoveHome)),
+        (crossterm::event::KeyCode::End, _) => Some(ChatInputAction::Edit(ChatEdit::MoveEnd)),
+        (crossterm::event::KeyCode::Backspace, _) => {
+            Some(ChatInputAction::Edit(ChatEdit::Backspace))
+        }
+        (crossterm::event::KeyCode::Delete, _) => Some(ChatInputAction::Edit(ChatEdit::Delete)),
+        (crossterm::event::KeyCode::Char(c), modifiers)
+            if !c.is_control()
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Edit(ChatEdit::InsertChar(c)))
+        }
+        _ => None,
+    }
+}
+
+fn apply_chat_edit(chat_input: &mut ChatInputState, edit: ChatEdit) {
+    match edit {
+        ChatEdit::MoveLeft => {
+            chat_input.cursor_col = chat_input.cursor_col.saturating_sub(1);
+        }
+        ChatEdit::MoveRight => {
+            chat_input.cursor_col = (chat_input.cursor_col + 1).min(chat_input_len(chat_input));
+        }
+        ChatEdit::MoveHome => {
+            chat_input.cursor_col = 0;
+        }
+        ChatEdit::MoveEnd => {
+            chat_input.cursor_col = chat_input_len(chat_input);
+        }
+        ChatEdit::Backspace => {
+            if chat_input.cursor_col > 0 {
+                let remove_at = chat_input.cursor_col - 1;
+                let start = chat_input_byte_index(chat_input.value.as_str(), remove_at);
+                let end = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+                chat_input.value.replace_range(start..end, "");
+                chat_input.cursor_col = remove_at;
+            }
+        }
+        ChatEdit::Delete => {
+            let len = chat_input_len(chat_input);
+            if chat_input.cursor_col < len {
+                let start = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+                let end =
+                    chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col + 1);
+                chat_input.value.replace_range(start..end, "");
+            }
+        }
+        ChatEdit::InsertChar(c) => {
+            insert_chat_text(chat_input, c.to_string().as_str());
+        }
+    }
+}
+
+fn insert_chat_text(chat_input: &mut ChatInputState, text: &str) {
+    let insert_at = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+    chat_input.value.insert_str(insert_at, text);
+    chat_input.cursor_col += text.chars().count();
+}
+
+fn chat_input_len(chat_input: &ChatInputState) -> usize {
+    chat_input.value.chars().count()
+}
+
+fn chat_input_byte_index(value: &str, char_index: usize) -> usize {
+    if char_index == 0 {
+        return 0;
+    }
+    value
+        .char_indices()
+        .nth(char_index)
+        .map(|(index, _)| index)
+        .unwrap_or(value.len())
+}
+
 fn textarea_navigation_action(
     target: ActiveTextarea,
-    key_event: &crossterm::event::KeyEvent,
+    _key_event: &crossterm::event::KeyEvent,
     code: crossterm::event::KeyCode,
     textarea: &TextArea<'static>,
 ) -> Option<CoreAction> {
-    if target == ActiveTextarea::ChatInput {
-        return chat_textarea_action(key_event, code);
-    }
     match code {
         crossterm::event::KeyCode::Tab => Some(textarea_next_field_action(target)),
         crossterm::event::KeyCode::BackTab => Some(textarea_prev_field_action(target)),
@@ -909,44 +1273,6 @@ fn textarea_prev_field_action(target: ActiveTextarea) -> CoreAction {
         ActiveTextarea::CreateDescription => CoreAction::CreatePrevField,
         ActiveTextarea::InsertText => CoreAction::InsertPrevField,
         ActiveTextarea::ChatInput => CoreAction::FocusPrev,
-    }
-}
-
-fn chat_textarea_action(
-    key_event: &crossterm::event::KeyEvent,
-    code: crossterm::event::KeyCode,
-) -> Option<CoreAction> {
-    match (code, key_event.modifiers) {
-        (crossterm::event::KeyCode::Tab, _) => Some(CoreAction::FocusNext),
-        (crossterm::event::KeyCode::BackTab, _) => Some(CoreAction::FocusPrev),
-        (crossterm::event::KeyCode::Enter, _) => Some(CoreAction::ChatSubmit),
-        (crossterm::event::KeyCode::Left, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
-                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
-        {
-            Some(CoreAction::ChatScopePrev)
-        }
-        (crossterm::event::KeyCode::Right, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
-                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
-        {
-            Some(CoreAction::ChatScopeNext)
-        }
-        (crossterm::event::KeyCode::PageUp, _) => Some(CoreAction::ChatScrollPageUp),
-        (crossterm::event::KeyCode::PageDown, _) => Some(CoreAction::ChatScrollPageDown),
-        (crossterm::event::KeyCode::Home, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
-        {
-            Some(CoreAction::ChatScrollHome)
-        }
-        (crossterm::event::KeyCode::End, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
-        {
-            Some(CoreAction::ChatScrollEnd)
-        }
-        _ => None,
     }
 }
 
@@ -979,7 +1305,7 @@ fn active_textarea(state: &CoreState) -> Option<ActiveTextarea> {
         return Some(ActiveTextarea::InsertText);
     }
 
-    if state.current_tab_id == KINIC_MEMORIES_TAB_ID && state.focus == PaneFocus::Extra {
+    if chat_input_active(state) {
         return Some(ActiveTextarea::ChatInput);
     }
 
@@ -990,7 +1316,7 @@ fn textarea_mut(textareas: &mut FormTextareas, target: ActiveTextarea) -> &mut T
     match target {
         ActiveTextarea::CreateDescription => &mut textareas.create_description,
         ActiveTextarea::InsertText => &mut textareas.insert_text,
-        ActiveTextarea::ChatInput => &mut textareas.chat_input,
+        ActiveTextarea::ChatInput => unreachable!("chat input no longer uses textarea"),
     }
 }
 
@@ -1000,7 +1326,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str(), false);
+    sync_chat_input_from_state(&mut textareas.chat_input, state.chat_input.as_str());
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1014,60 +1340,46 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
 }
 
+#[cfg(test)]
+fn chat_input_from_text(value: &str) -> ChatInputState {
+    let single_line_value = flatten_chat_input_for_display(value);
+    ChatInputState {
+        cursor_col: single_line_value.chars().count(),
+        value: single_line_value,
+    }
+}
+
+fn chat_input_active(state: &CoreState) -> bool {
+    state.current_tab_id == KINIC_MEMORIES_TAB_ID && state.focus == PaneFocus::Extra
+}
+
 // Chat input is rendered and edited as a true single-line widget.
-fn chat_input_display_value(textarea: &TextArea<'static>) -> String {
-    textarea.lines().join("\n")
+fn chat_input_display_value(chat_input: &ChatInputState) -> String {
+    chat_input.value.clone()
 }
 
 fn chat_input_submit_value(value: &str) -> String {
     normalize_chat_input_lines(value)
 }
 
-fn chat_input_display_cursor_col(textarea: &TextArea<'static>) -> usize {
-    let lines = textarea.lines();
-    let last_row = lines.len().saturating_sub(1);
-    let (cursor_row, cursor_col) = textarea.cursor();
-    let effective_row = cursor_row.min(last_row);
-    let mut prefix_lines = lines
-        .iter()
-        .take(effective_row)
-        .map(|line| line.as_str().to_string())
-        .collect::<Vec<_>>();
-    let current_prefix = lines
-        .get(effective_row)
-        .map(|line| line.chars().take(cursor_col).collect::<String>())
-        .unwrap_or_default();
-    prefix_lines.push(current_prefix);
-    flatten_chat_input_for_display(prefix_lines.join("\n").as_str())
-        .chars()
-        .count()
-}
-
 fn chat_input_cursor(
     active: Option<ActiveTextarea>,
-    textarea: &TextArea<'static>,
+    chat_input: &ChatInputState,
 ) -> Option<(usize, usize)> {
     if active != Some(ActiveTextarea::ChatInput) {
         return None;
     }
-    Some((0, textarea.cursor().1))
+    Some((0, chat_input.cursor_col))
 }
 
-fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str, preserve_cursor: bool) {
-    // Rebuild chat input from its flattened single-line form so pasted multiline
-    // content cannot leave hidden rows behind inside the widget.
+fn sync_chat_input_from_state(chat_input: &mut ChatInputState, value: &str) {
     let single_line_value = flatten_chat_input_for_display(value);
-    if textarea.lines().join("\n") == single_line_value {
+    if chat_input.value == single_line_value {
+        chat_input.cursor_col = chat_input.cursor_col.min(chat_input_len(chat_input));
         return;
     }
-    let cursor_col = if preserve_cursor {
-        chat_input_display_cursor_col(textarea).min(single_line_value.chars().count())
-    } else {
-        single_line_value.chars().count()
-    }
-    .min(u16::MAX as usize) as u16;
-    sync_textarea_from_string(textarea, single_line_value.as_str());
-    textarea.move_cursor(CursorMove::Jump(0, cursor_col));
+    chat_input.value = single_line_value;
+    chat_input.cursor_col = chat_input_len(chat_input);
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
@@ -1089,11 +1401,18 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let display_chat_input =
-        flatten_chat_input_for_display(textareas.chat_input.lines().join("\n").as_str());
+    let display_chat_input = chat_input_display_value(&textareas.chat_input);
     if state.chat_input != display_chat_input {
         state.chat_input = display_chat_input;
     }
+}
+
+fn sync_state_from_chat_input(state: &mut CoreState, textareas: &mut FormTextareas) {
+    let display_chat_input = chat_input_display_value(&textareas.chat_input);
+    if state.chat_input != display_chat_input {
+        state.chat_input = display_chat_input;
+    }
+    sync_chat_command_selection(textareas, state.chat_input.as_str());
 }
 
 fn textarea_cursor(

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -514,7 +514,7 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 }
 
 #[test]
-fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
+fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("first line\nsecond line");
@@ -525,7 +525,7 @@ fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
     assert_eq!(state.chat_input, "first line second line");
     assert_eq!(
         textareas.chat_input.lines().join("\n"),
-        "first line\nsecond line"
+        "first line second line"
     );
 }
 
@@ -548,7 +548,7 @@ fn chat_textarea_display_value_preserves_trailing_space() {
     };
 
     assert_eq!(
-        normalized_chat_textarea_value(&textareas.chat_input),
+        chat_input_display_value(&textareas.chat_input),
         "hello "
     );
 }
@@ -601,10 +601,13 @@ fn chat_input_cursor_keeps_trailing_space_visible() {
 }
 
 #[test]
-fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
+fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
     let mut textarea = textarea_from_text("first line\nsecond line");
     textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
 
+    sync_chat_textarea_from_state(&mut textarea, "first line second line", true);
+
+    assert_eq!(textarea.lines().join("\n"), "first line second line");
     assert_eq!(
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
         Some((0, 17))
@@ -619,8 +622,167 @@ fn chat_textarea_display_value_keeps_space_before_next_char() {
     };
 
     assert_eq!(
-        normalized_chat_textarea_value(&textareas.chat_input),
+        chat_input_display_value(&textareas.chat_input),
         "hello w"
+    );
+}
+
+#[test]
+fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+
+    sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let moved_up = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Up,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat up");
+    let cursor_after_up = textareas.chat_input.cursor();
+    let moved_down = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat down");
+
+    assert!(moved_up);
+    assert!(moved_down);
+    assert_eq!(cursor_after_up.0, 0);
+    assert_eq!(textareas.chat_input.cursor().0, 0);
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second line"
+    );
+}
+
+#[test]
+fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+
+    sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Home,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat home");
+    assert_eq!(textareas.chat_input.cursor(), (0, 0));
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat end");
+    assert_eq!(textareas.chat_input.cursor(), (0, 22));
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Backspace,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat backspace");
+
+    assert_eq!(state.chat_input, "first line second lin");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second lin"
+    );
+    assert_eq!(textareas.chat_input.cursor(), (0, 21));
+}
+
+#[test]
+fn chat_textarea_midline_space_input_preserves_cursor_position() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "helloworld".to_string(),
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+    for _ in 0..5 {
+        textareas.chat_input.input(textarea_input_from_key_event(
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Left,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        ));
+    }
+    let cursor_before = textareas.chat_input.cursor();
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat textarea input");
+
+    assert!(handled);
+    assert_eq!(cursor_before, (0, 5));
+    assert_eq!(state.chat_input, "hello world");
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello world");
+    assert_eq!(textareas.chat_input.cursor(), (0, 6));
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textareas.chat_input),
+        Some((0, 6))
     );
 }
 

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -61,6 +61,21 @@ fn test_runtime_config() -> RuntimeLoopConfig {
     }
 }
 
+fn host_key(
+    code: crossterm::event::KeyCode,
+    modifiers: crossterm::event::KeyModifiers,
+) -> HostInputEvent {
+    HostInputEvent::Key {
+        key_event: crossterm::event::KeyEvent::new(code, modifiers),
+        code,
+        modifiers,
+    }
+}
+
+fn host_paste(text: &str) -> HostInputEvent {
+    HostInputEvent::Paste(text.to_string())
+}
+
 #[test]
 fn normalize_focus_keeps_memories_on_tabs_after_tab_switch() {
     let mut state = CoreState {
@@ -272,6 +287,84 @@ fn handle_overlay_input_consumes_unknown_selector_keys() {
 }
 
 #[test]
+fn paste_input_updates_search_query() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        focus: PaneFocus::Search,
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "alpha\nbeta")
+        .expect("search paste");
+
+    assert!(handled);
+    assert_eq!(state.query, "alpha beta");
+}
+
+#[test]
+fn paste_input_updates_rename_modal_name() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        rename_memory: RenameMemoryModalState {
+            form: TextInputModalState {
+                open: true,
+                ..TextInputModalState::default()
+            },
+            focus: tui_kit_runtime::RenameModalFocus::Name,
+            ..RenameMemoryModalState::default()
+        },
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "Alpha Memory")
+        .expect("rename paste");
+
+    assert!(handled);
+    assert_eq!(state.rename_memory.form.value, "Alpha Memory");
+}
+
+#[test]
+fn paste_input_normalizes_crlf_for_access_control_principal() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        access_control: tui_kit_runtime::AccessControlModalState {
+            open: true,
+            mode: tui_kit_runtime::AccessControlMode::Add,
+            focus: tui_kit_runtime::AccessControlFocus::Principal,
+            ..tui_kit_runtime::AccessControlModalState::default()
+        },
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "aaaa\r\nbbbb\rcccc")
+        .expect("access paste");
+
+    assert!(handled);
+    assert_eq!(state.access_control.principal_id, "aaaa bbbb cccc");
+}
+
+#[test]
+fn paste_input_updates_create_name_when_form_focus_is_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_CREATE_TAB_ID.to_string(),
+        focus: PaneFocus::Form,
+        create_focus: tui_kit_runtime::CreateModalFocus::Name,
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "new memory")
+        .expect("create paste");
+
+    assert!(handled);
+    assert_eq!(state.create_name, "new memory");
+}
+
+#[test]
 fn textarea_input_updates_create_description_with_newlines() {
     let mut provider = TestProvider::ok();
     let mut hooks = NoopRuntimeHooks;
@@ -288,7 +381,7 @@ fn textarea_input_updates_create_description_with_newlines() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char('a'),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -301,7 +394,7 @@ fn textarea_input_updates_create_description_with_newlines() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -331,7 +424,7 @@ fn textarea_up_on_first_create_description_row_moves_to_previous_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -370,7 +463,7 @@ fn textarea_down_on_last_create_description_row_moves_to_submit() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -405,7 +498,7 @@ fn textarea_down_inside_insert_text_moves_cursor_before_leaving_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -443,7 +536,7 @@ fn textarea_down_on_last_insert_text_row_moves_to_next_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -473,7 +566,7 @@ fn chat_textarea_shift_enter_submits_instead_of_inserting_newline() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::SHIFT,
         ),
@@ -502,7 +595,7 @@ fn chat_textarea_enter_submits_without_inserting_text() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -515,13 +608,24 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 
 #[test]
 fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
-    let mut state = CoreState::default();
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("first line\nsecond line");
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("first line\nsecond line"),
+    )
+    .expect("chat paste");
 
-    sync_state_from_textareas(&mut state, &textareas);
-    sync_form_textareas_from_state(&mut textareas, &state);
-
+    assert!(handled);
     assert_eq!(state.chat_input, "first line second line");
     assert_eq!(
         textareas.chat_input.lines().join("\n"),
@@ -530,10 +634,38 @@ fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
 }
 
 #[test]
+fn chat_textarea_crlf_paste_normalizes_widget_and_state_to_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("first line\r\nsecond line\rthird line"),
+    )
+    .expect("chat paste");
+
+    assert!(handled);
+    assert_eq!(state.chat_input, "first line second line third line");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second line third line"
+    );
+    assert_eq!(textareas.chat_input.cursor(), (0, 33));
+}
+
+#[test]
 fn chat_textarea_sync_state_preserves_trailing_space() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
 
     sync_state_from_textareas(&mut state, &textareas);
 
@@ -543,20 +675,17 @@ fn chat_textarea_sync_state_preserves_trailing_space() {
 #[test]
 fn chat_textarea_display_value_preserves_trailing_space() {
     let textareas = FormTextareas {
-        chat_input: textarea_from_text("hello "),
+        chat_input: chat_input_from_text("hello "),
         ..FormTextareas::default()
     };
 
-    assert_eq!(
-        chat_input_display_value(&textareas.chat_input),
-        "hello "
-    );
+    assert_eq!(chat_input_display_value(&textareas.chat_input), "hello ");
 }
 
 #[test]
 fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget() {
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
     let state = CoreState {
         chat_input: "hello ".to_string(),
         ..CoreState::default()
@@ -570,7 +699,7 @@ fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget()
 #[test]
 fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
     textareas.chat_input.input(textarea_input_from_key_event(
         crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Left,
@@ -591,8 +720,7 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
 
 #[test]
 fn chat_input_cursor_keeps_trailing_space_visible() {
-    let mut textarea = textarea_from_text("hello ");
-    textarea.move_cursor(ratatui_textarea::CursorMove::End);
+    let textarea = chat_input_from_text("hello ");
 
     assert_eq!(
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
@@ -602,10 +730,10 @@ fn chat_input_cursor_keeps_trailing_space_visible() {
 
 #[test]
 fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
-    let mut textarea = textarea_from_text("first line\nsecond line");
-    textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
+    let mut textarea = chat_input_from_text("first line\nsecond line");
+    textarea.cursor_col = 17;
 
-    sync_chat_textarea_from_state(&mut textarea, "first line second line", true);
+    sync_chat_input_from_state(&mut textarea, "first line second line");
 
     assert_eq!(textarea.lines().join("\n"), "first line second line");
     assert_eq!(
@@ -617,14 +745,11 @@ fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
 #[test]
 fn chat_textarea_display_value_keeps_space_before_next_char() {
     let textareas = FormTextareas {
-        chat_input: textarea_from_text("hello w"),
+        chat_input: chat_input_from_text("hello w"),
         ..FormTextareas::default()
     };
 
-    assert_eq!(
-        chat_input_display_value(&textareas.chat_input),
-        "hello w"
-    );
+    assert_eq!(chat_input_display_value(&textareas.chat_input), "hello w");
 }
 
 #[test]
@@ -637,7 +762,7 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
 
@@ -649,7 +774,7 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -661,15 +786,15 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
     )
     .expect("chat down");
 
-    assert!(moved_up);
-    assert!(moved_down);
+    assert!(!moved_up);
+    assert!(!moved_down);
     assert_eq!(cursor_after_up.0, 0);
     assert_eq!(textareas.chat_input.cursor().0, 0);
     assert_eq!(
@@ -688,7 +813,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
 
@@ -700,7 +825,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Home,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -713,7 +838,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::End,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -726,7 +851,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Backspace,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -768,7 +893,7 @@ fn chat_textarea_midline_space_input_preserves_cursor_position() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char(' '),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -804,7 +929,7 @@ fn chat_textarea_space_input_updates_state_and_widget_cursor() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char(' '),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -864,7 +989,7 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -878,7 +1003,7 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -891,83 +1016,109 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
 
 #[test]
 fn chat_textarea_shift_arrows_switch_scope() {
-    let action_prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_prev = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Left,
             crossterm::event::KeyModifiers::SHIFT,
         ),
         crossterm::event::KeyCode::Left,
+        crossterm::event::KeyModifiers::SHIFT,
     );
-    let action_next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_next = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Right,
             crossterm::event::KeyModifiers::SHIFT,
         ),
         crossterm::event::KeyCode::Right,
+        crossterm::event::KeyModifiers::SHIFT,
     );
 
-    assert_eq!(action_prev, Some(CoreAction::ChatScopePrev));
-    assert_eq!(action_next, Some(CoreAction::ChatScopeNext));
+    assert_eq!(
+        action_prev,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+    );
+    assert_eq!(
+        action_next,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+    );
 }
 
 #[test]
 fn chat_textarea_shift_arrows_switch_scope_with_extra_modifier_bits() {
     let shift_super = crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::SUPER;
-    let prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Left, shift_super),
+    let prev = chat_input_action(
+        crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Left, shift_super),
         crossterm::event::KeyCode::Left,
+        shift_super,
     );
-    let next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Right, shift_super),
+    let next = chat_input_action(
+        crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Right, shift_super),
         crossterm::event::KeyCode::Right,
+        shift_super,
     );
-    assert_eq!(prev, Some(CoreAction::ChatScopePrev));
-    assert_eq!(next, Some(CoreAction::ChatScopeNext));
+    assert_eq!(
+        prev,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+    );
+    assert_eq!(
+        next,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+    );
 }
 
 #[test]
 fn chat_textarea_shift_arrow_with_control_or_alt_does_not_switch_scope() {
     assert_eq!(
-        chat_textarea_action(
-            &crossterm::event::KeyEvent::new(
+        chat_input_action(
+            crossterm::event::KeyEvent::new(
                 crossterm::event::KeyCode::Left,
                 crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::CONTROL,
             ),
             crossterm::event::KeyCode::Left,
+            crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::CONTROL,
         ),
-        None
+        Some(ChatInputAction::Edit(ChatEdit::MoveLeft))
     );
     assert_eq!(
-        chat_textarea_action(
-            &crossterm::event::KeyEvent::new(
+        chat_input_action(
+            crossterm::event::KeyEvent::new(
                 crossterm::event::KeyCode::Right,
                 crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::ALT,
             ),
             crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::ALT,
         ),
-        None
+        Some(ChatInputAction::Edit(ChatEdit::MoveRight))
     );
 }
 
 #[test]
 fn chat_textarea_brackets_remain_regular_input() {
-    let action_prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_prev = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char('['),
             crossterm::event::KeyModifiers::NONE,
         ),
         crossterm::event::KeyCode::Char('['),
+        crossterm::event::KeyModifiers::NONE,
     );
-    let action_next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_next = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char(']'),
             crossterm::event::KeyModifiers::NONE,
         ),
         crossterm::event::KeyCode::Char(']'),
+        crossterm::event::KeyModifiers::NONE,
     );
 
-    assert_eq!(action_prev, None);
-    assert_eq!(action_next, None);
+    assert_eq!(
+        action_prev,
+        Some(ChatInputAction::Edit(ChatEdit::InsertChar('[')))
+    );
+    assert_eq!(
+        action_next,
+        Some(ChatInputAction::Edit(ChatEdit::InsertChar(']')))
+    );
 }
 
 #[test]
@@ -1051,7 +1202,7 @@ fn chat_submit_normalizes_multiline_input_before_sending_message() {
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
     sync_state_from_textareas(&mut state, &textareas);

--- a/tui/crates/tui-kit-host/src/terminal.rs
+++ b/tui/crates/tui-kit-host/src/terminal.rs
@@ -10,8 +10,8 @@ use std::{
 
 use crossterm::{
     event::{
-        DisableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-        PushKeyboardEnhancementFlags,
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{
@@ -49,6 +49,7 @@ fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<bool> {
         execute!(
             terminal.backend_mut(),
             EnterAlternateScreen,
+            EnableBracketedPaste,
             PushKeyboardEnhancementFlags(
                 KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                     | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
@@ -56,7 +57,11 @@ fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<bool> {
             )
         )?;
     } else {
-        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        execute!(
+            terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableBracketedPaste
+        )?;
     }
     terminal.hide_cursor()?;
     Ok(keyboard_enhancement_enabled)
@@ -72,12 +77,14 @@ fn leave_terminal(
         execute!(
             terminal.backend_mut(),
             PopKeyboardEnhancementFlags,
+            DisableBracketedPaste,
             LeaveAlternateScreen,
             DisableMouseCapture
         )?;
     } else {
         execute!(
             terminal.backend_mut(),
+            DisableBracketedPaste,
             LeaveAlternateScreen,
             DisableMouseCapture
         )?;

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -28,6 +28,7 @@ pub fn matching_slash_commands(input: &str) -> Vec<&'static str> {
         .collect()
 }
 
+/// Resolve a slash command from the normalized submit payload.
 pub fn chat_slash_command_action(input: &str) -> Option<CoreAction> {
     match input.trim() {
         "/new" => Some(CoreAction::ChatNewThread),
@@ -44,13 +45,14 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
         .and_then(chat_slash_command_action)
 }
 
-/// Collapse multiline chat input to one line for in-progress display.
+/// Collapse multiline chat input to one line for in-progress display and editing.
 /// This preserves user-typed spacing and only replaces line breaks with spaces.
 pub fn flatten_chat_input_for_display(value: &str) -> String {
     value.split('\n').collect::<Vec<_>>().join(" ")
 }
 
-/// Collapse multiline chat input to one line (trimmed lines joined with spaces).
+/// Collapse multiline chat input to the final submit/command-match form.
+/// Each line is trimmed before joining so pasted newlines do not leak layout-only spacing.
 pub fn normalize_chat_input_lines(value: &str) -> String {
     value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
 }

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -48,13 +48,24 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
 /// Collapse multiline chat input to one line for in-progress display and editing.
 /// This preserves user-typed spacing and only replaces line breaks with spaces.
 pub fn flatten_chat_input_for_display(value: &str) -> String {
-    value.split('\n').collect::<Vec<_>>().join(" ")
+    canonicalize_chat_line_endings(value)
+        .split('\n')
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Collapse multiline chat input to the final submit/command-match form.
 /// Each line is trimmed before joining so pasted newlines do not leak layout-only spacing.
 pub fn normalize_chat_input_lines(value: &str) -> String {
-    value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
+    canonicalize_chat_line_endings(value)
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn canonicalize_chat_line_endings(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 #[cfg(test)]
@@ -75,7 +86,17 @@ mod tests {
     }
 
     #[test]
+    fn flatten_chat_input_for_display_normalizes_crlf_and_cr() {
+        assert_eq!(flatten_chat_input_for_display("a\r\nb\rc"), "a b c");
+    }
+
+    #[test]
     fn normalize_chat_input_lines_joins_trimmed_lines() {
         assert_eq!(normalize_chat_input_lines("a\n  b  \n c"), "a b c");
+    }
+
+    #[test]
+    fn normalize_chat_input_lines_handles_crlf_and_cr() {
+        assert_eq!(normalize_chat_input_lines("a\r\n  b \rc"), "a b c");
     }
 }

--- a/tui/crates/tui-kit-runtime/src/lib.rs
+++ b/tui/crates/tui-kit-runtime/src/lib.rs
@@ -27,6 +27,25 @@ pub const FILE_MODE_ALLOWED_EXTENSIONS: &[&str] = &[
     "md", "markdown", "mdx", "txt", "json", "yaml", "yml", "csv", "log", "pdf",
 ];
 
+/// Transfer amount accepts ASCII digits and a single decimal separator.
+/// Fractional precision is capped at 8 places to match ledger parsing.
+pub fn transfer_amount_accepts_char(current: &str, next: char) -> bool {
+    if next.is_ascii_digit() {
+        let fraction_len = current
+            .split_once('.')
+            .map_or(0, |(_, fraction)| fraction.chars().count());
+        return !current.contains('.') || fraction_len < 8;
+    }
+
+    next == '.' && !current.contains('.')
+}
+
+/// Principal-like identifiers in the TUI use lowercase text, digits, and hyphens.
+/// Final validity still belongs to `Principal::from_text(...)` at submit time.
+pub fn principal_text_accepts_char(next: char) -> bool {
+    next.is_ascii_lowercase() || next.is_ascii_digit() || next == '-'
+}
+
 /// Core result type used by provider and reducer contracts.
 pub type CoreResult<T> = Result<T, CoreError>;
 
@@ -1116,7 +1135,11 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             {
                 return;
             }
-            state.access_control.principal_id.push(*c);
+            if principal_text_accepts_char(*c) {
+                state.access_control.principal_id.push(*c);
+            } else {
+                return;
+            }
             clear_access_control_error(state);
         }
         CoreAction::AccessBackspace => {
@@ -1222,6 +1245,9 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             close_add_memory_modal(state);
         }
         CoreAction::AddMemoryInput(c) => {
+            if !principal_text_accepts_char(*c) {
+                return;
+            }
             apply_text_input_modal_command(
                 &mut state.add_memory,
                 true,
@@ -1326,8 +1352,20 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
                 return;
             }
             match state.transfer_modal.focus {
-                TransferModalFocus::Principal => state.transfer_modal.principal_id.push(*c),
-                TransferModalFocus::Amount => state.transfer_modal.amount.push(*c),
+                TransferModalFocus::Principal => {
+                    if principal_text_accepts_char(*c) {
+                        state.transfer_modal.principal_id.push(*c);
+                    } else {
+                        return;
+                    }
+                }
+                TransferModalFocus::Amount => {
+                    if transfer_amount_accepts_char(&state.transfer_modal.amount, *c) {
+                        state.transfer_modal.amount.push(*c);
+                    } else {
+                        return;
+                    }
+                }
                 TransferModalFocus::Max | TransferModalFocus::Submit => {}
             }
             clear_transfer_error(state);
@@ -4066,6 +4104,102 @@ mod tests {
 
         assert_eq!(state.transfer_modal.amount, "9.99900000");
         assert_eq!(state.transfer_modal.focus, TransferModalFocus::Submit);
+    }
+
+    #[test]
+    fn transfer_amount_input_rejects_non_numeric_characters() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Amount,
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        apply_core_action(&mut state, &CoreAction::TransferInput('1'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('x'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('.'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('2'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('.'));
+
+        assert_eq!(state.transfer_modal.amount, "1.2");
+    }
+
+    #[test]
+    fn transfer_amount_input_caps_fractional_precision_at_eight_digits() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Amount,
+                amount: "0.".to_string(),
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "123456789".chars() {
+            apply_core_action(&mut state, &CoreAction::TransferInput(next));
+        }
+
+        assert_eq!(state.transfer_modal.amount, "0.12345678");
+    }
+
+    #[test]
+    fn transfer_principal_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Principal,
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "abC-1_+".chars() {
+            apply_core_action(&mut state, &CoreAction::TransferInput(next));
+        }
+
+        assert_eq!(state.transfer_modal.principal_id, "ab-1");
+    }
+
+    #[test]
+    fn access_principal_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            access_control: AccessControlModalState {
+                open: true,
+                mode: AccessControlMode::Add,
+                focus: AccessControlFocus::Principal,
+                ..AccessControlModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "anonyMous!?-1".chars() {
+            apply_core_action(&mut state, &CoreAction::AccessInput(next));
+        }
+
+        assert_eq!(state.access_control.principal_id, "anonyous-1");
+    }
+
+    #[test]
+    fn add_memory_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            add_memory: TextInputModalState {
+                open: true,
+                ..TextInputModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "aaaaA-aa\n_1".chars() {
+            apply_core_action(&mut state, &CoreAction::AddMemoryInput(next));
+        }
+
+        assert_eq!(state.add_memory.value, "aaaa-aa1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add paste handling for TUI chat and modal/form inputs across host and runtime layers
- update CLI/TUI preferences and capability paths to support the new input behavior consistently
- refresh related docs and tests for chat, settings, preferences, and capabilities flows

## Testing
- `cargo fmt --all`
- `./.local/lint.sh`
- `cargo test -p tui-kit-runtime transfer_amount_input`
- `cargo test -p tui-kit-runtime principal_input`
- `cargo test -p tui-kit-runtime add_memory_input_rejects_non_principal_characters`
- `cargo test validate_transfer_submit_rejects_invalid_principal_and_overspend`