### PR TITLE
Normalize TUI paste handling and stabilize single-line chat input

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -278,7 +278,7 @@ Main items you can review:
 - `d` in the saved tag list: delete a tag
 - `Ctrl+R`: refresh `Principal ID` and `KINIC balance`
 
-The transfer modal accepts a recipient principal and an amount in KINIC. `Max` fills the largest sendable amount after subtracting the current ledger fee, and `Submit` opens a confirmation step before the transfer is sent.
+The transfer modal accepts a recipient principal and an amount in KINIC. The amount field accepts digits and a single decimal point, with up to 8 fractional digits. `Max` fills the largest sendable amount after subtracting the current ledger fee, and `Submit` opens a confirmation step before the transfer is sent.
 
 Values saved from `Settings` persist across restarts.
 

--- a/tui/crates/tui-kit-host/src/lib.rs
+++ b/tui/crates/tui-kit-host/src/lib.rs
@@ -20,11 +20,14 @@ use tui_kit_runtime::{
 pub const DEFAULT_TAB_IDS: [&str; 4] = ["tab-1", "tab-2", "tab-3", "tab-4"];
 
 /// Host-level normalized input event used by app loops.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HostInputEvent {
-    pub key_event: KeyEvent,
-    pub code: KeyCode,
-    pub modifiers: KeyModifiers,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostInputEvent {
+    Key {
+        key_event: KeyEvent,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+    },
+    Paste(String),
 }
 
 /// Poll and normalize crossterm events for host loops.
@@ -37,11 +40,12 @@ pub fn poll_host_input(timeout: Duration) -> std::io::Result<Option<HostInputEve
 
 fn normalize_host_input_event(event: Event) -> Option<HostInputEvent> {
     match event {
-        Event::Key(key) if key.kind == KeyEventKind::Press => Some(HostInputEvent {
+        Event::Key(key) if key.kind == KeyEventKind::Press => Some(HostInputEvent::Key {
             key_event: key,
             code: key.code,
             modifiers: key.modifiers,
         }),
+        Event::Paste(text) => Some(HostInputEvent::Paste(text)),
         _ => None,
     }
 }

--- a/tui/crates/tui-kit-host/src/lib_tests.rs
+++ b/tui/crates/tui-kit-host/src/lib_tests.rs
@@ -27,6 +27,14 @@ mod key_mapping {
 
         assert_eq!(normalize_host_input_event(key_event), None);
     }
+
+    #[test]
+    fn normalize_host_input_event_preserves_paste_payload() {
+        assert_eq!(
+            normalize_host_input_event(Event::Paste("a\nb".to_string())),
+            Some(HostInputEvent::Paste("a\nb".to_string()))
+        );
+    }
 }
 
 mod tab_resolution {

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -159,7 +159,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             terminal.draw(|frame| {
                 let focus = ui_focus_from_pane(state.focus);
                 let insert_file_path_display = insert_file_path_display(&state);
-                let visible_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+                let visible_chat_input = chat_input_display_value(&textareas.chat_input);
                 let ui = TuiKitUi::new(&theme)
                     .ui_config(ui_config())
                     .ui_summaries(&state.list_items)
@@ -762,6 +762,11 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
         textarea.input(textarea_input_from_key_event(*key_event));
         sync_state_from_textareas(state, textareas);
         if target == ActiveTextarea::ChatInput {
+            sync_chat_textarea_from_state(
+                &mut textareas.chat_input,
+                state.chat_input.as_str(),
+                true,
+            );
             sync_chat_command_selection(textareas, state.chat_input.as_str());
         }
         return Ok(true);
@@ -786,7 +791,8 @@ fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
     hooks: &mut H,
     textareas: &mut FormTextareas,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    state.chat_input = normalize_chat_input_lines(state.chat_input.as_str());
+    // Submit and slash-command matching operate on the normalized single-line payload.
+    state.chat_input = chat_input_submit_value(state.chat_input.as_str());
     sync_chat_command_selection(textareas, state.chat_input.as_str());
     if let Some(command_action) =
         selected_slash_command_action(state.chat_input.as_str(), textareas.chat_command_selected)
@@ -994,7 +1000,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str());
+    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str(), false);
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1008,11 +1014,16 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
 }
 
-fn normalized_chat_textarea_value(textarea: &TextArea<'static>) -> String {
-    flatten_chat_input_for_display(textarea.lines().join("\n").as_str())
+// Chat input is rendered and edited as a true single-line widget.
+fn chat_input_display_value(textarea: &TextArea<'static>) -> String {
+    textarea.lines().join("\n")
 }
 
-fn normalized_chat_cursor_col(textarea: &TextArea<'static>) -> usize {
+fn chat_input_submit_value(value: &str) -> String {
+    normalize_chat_input_lines(value)
+}
+
+fn chat_input_display_cursor_col(textarea: &TextArea<'static>) -> usize {
     let lines = textarea.lines();
     let last_row = lines.len().saturating_sub(1);
     let (cursor_row, cursor_col) = textarea.cursor();
@@ -1039,18 +1050,24 @@ fn chat_input_cursor(
     if active != Some(ActiveTextarea::ChatInput) {
         return None;
     }
-    Some((0, normalized_chat_cursor_col(textarea)))
+    Some((0, textarea.cursor().1))
 }
 
-fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str) {
-    // Chat input remains a single-line UI, but the widget may still hold raw pasted
-    // newlines or trailing spaces while editing. Only rebuild when the normalized
-    // text actually diverges so equivalent edits keep the cursor stable.
-    if normalized_chat_textarea_value(textarea) == value {
+fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str, preserve_cursor: bool) {
+    // Rebuild chat input from its flattened single-line form so pasted multiline
+    // content cannot leave hidden rows behind inside the widget.
+    let single_line_value = flatten_chat_input_for_display(value);
+    if textarea.lines().join("\n") == single_line_value {
         return;
     }
-    sync_textarea_from_string(textarea, value);
-    textarea.move_cursor(CursorMove::End);
+    let cursor_col = if preserve_cursor {
+        chat_input_display_cursor_col(textarea).min(single_line_value.chars().count())
+    } else {
+        single_line_value.chars().count()
+    }
+    .min(u16::MAX as usize) as u16;
+    sync_textarea_from_string(textarea, single_line_value.as_str());
+    textarea.move_cursor(CursorMove::Jump(0, cursor_col));
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
@@ -1072,7 +1089,8 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let display_chat_input = normalized_chat_textarea_value(&textareas.chat_input);
+    let display_chat_input =
+        flatten_chat_input_for_display(textareas.chat_input.lines().join("\n").as_str());
     if state.chat_input != display_chat_input {
         state.chat_input = display_chat_input;
     }

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -1,7 +1,7 @@
 #[path = "form_tab_flow.rs"]
 mod form_tab_flow;
 
-use ratatui_textarea::{CursorMove, Input as TextAreaInput, Key as TextAreaKey, TextArea};
+use ratatui_textarea::{Input as TextAreaInput, Key as TextAreaKey, TextArea};
 use std::{io, time::Duration};
 use tui_kit_render::theme::Theme;
 use tui_kit_render::ui::app::list_viewport_height_for_area_with_tabs;
@@ -71,10 +71,37 @@ enum ActiveTextarea {
     ChatInput,
 }
 
+// Memories chat uses a dedicated single-line model so chat shortcuts and paste
+// behavior stay independent from multiline textarea defaults.
+#[derive(Default)]
+struct ChatInputState {
+    value: String,
+    cursor_col: usize,
+}
+
+impl ChatInputState {
+    #[cfg(test)]
+    fn lines(&self) -> Vec<String> {
+        vec![self.value.clone()]
+    }
+
+    #[cfg(test)]
+    fn cursor(&self) -> (usize, usize) {
+        (0, self.cursor_col)
+    }
+
+    #[cfg(test)]
+    fn input(&mut self, input: TextAreaInput) {
+        if let Some(action) = chat_edit_from_textarea_input(input) {
+            apply_chat_edit(self, action);
+        }
+    }
+}
+
 struct FormTextareas {
     create_description: TextArea<'static>,
     insert_text: TextArea<'static>,
-    chat_input: TextArea<'static>,
+    chat_input: ChatInputState,
     chat_command_selected: usize,
 }
 
@@ -83,7 +110,7 @@ impl Default for FormTextareas {
         Self {
             create_description: textarea_from_text(""),
             insert_text: textarea_from_text(""),
-            chat_input: textarea_from_text(""),
+            chat_input: ChatInputState::default(),
             chat_command_selected: 0,
         }
     }
@@ -250,176 +277,201 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
             let Some(input) = poll_host_input(poll_duration)? else {
                 continue;
             };
-            let HostInputEvent {
-                key_event,
-                code,
-                modifiers,
-            } = input;
-
-            match handle_overlay_input(provider, &mut state, show_settings, code, modifiers) {
-                OverlayInputResult::NotHandled => {}
-                OverlayInputResult::Consumed => continue,
-                OverlayInputResult::CloseSettings => {
-                    show_settings = false;
-                    continue;
-                }
-                OverlayInputResult::DispatchError(error) => {
-                    state.status_message = Some(error);
-                    continue;
-                }
-                OverlayInputResult::ApplyEffects(effects) => {
-                    hooks.on_effects(provider, &mut state, &effects);
-                    execute_effects_to_status(&mut state, effects);
+            if matches!(input, HostInputEvent::Paste(_))
+                && handle_textarea_input(provider, &mut state, hooks, &mut textareas, &input)?
+            {
+                continue;
+            }
+            if let HostInputEvent::Paste(text) = &input {
+                if handle_paste_input(provider, &mut state, hooks, text.as_str())? {
                     continue;
                 }
             }
+            let (_key_event, code, modifiers) = match &input {
+                HostInputEvent::Key {
+                    key_event,
+                    code,
+                    modifiers,
+                } => (Some(*key_event), Some(*code), Some(*modifiers)),
+                HostInputEvent::Paste(_) => (None, None, None),
+            };
 
-            if handle_textarea_input(provider, &mut state, hooks, &mut textareas, &key_event)? {
+            if let (Some(code), Some(modifiers)) = (code, modifiers) {
+                match handle_overlay_input(provider, &mut state, show_settings, code, modifiers) {
+                    OverlayInputResult::NotHandled => {}
+                    OverlayInputResult::Consumed => continue,
+                    OverlayInputResult::CloseSettings => {
+                        show_settings = false;
+                        continue;
+                    }
+                    OverlayInputResult::DispatchError(error) => {
+                        state.status_message = Some(error);
+                        continue;
+                    }
+                    OverlayInputResult::ApplyEffects(effects) => {
+                        hooks.on_effects(provider, &mut state, &effects);
+                        execute_effects_to_status(&mut state, effects);
+                        continue;
+                    }
+                }
+            }
+
+            if handle_textarea_input(provider, &mut state, hooks, &mut textareas, &input)? {
                 continue;
             }
 
-            match global_command_for_key(
-                code,
-                modifiers,
-                state.focus,
-                state.current_tab_id.as_str(),
-                show_help,
-                show_settings,
-                state.query.is_empty(),
-            ) {
-                HostGlobalCommand::None => {}
-                HostGlobalCommand::CloseHelp => {
-                    show_help = false;
-                    continue;
-                }
-                HostGlobalCommand::CloseSettings => {
-                    show_settings = false;
-                    continue;
-                }
-                HostGlobalCommand::CloseChat => {
-                    if let Err(error) =
-                        dispatch_with_effects(provider, &mut state, hooks, &CoreAction::ToggleChat)
-                    {
-                        state.status_message = Some(error);
+            if let (Some(code), Some(modifiers)) = (code, modifiers) {
+                match global_command_for_key(
+                    code,
+                    modifiers,
+                    state.focus,
+                    state.current_tab_id.as_str(),
+                    show_help,
+                    show_settings,
+                    state.query.is_empty(),
+                ) {
+                    HostGlobalCommand::None => {}
+                    HostGlobalCommand::CloseHelp => {
+                        show_help = false;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::BackToTabs => {
-                    state.focus = PaneFocus::Tabs;
-                    continue;
-                }
-                HostGlobalCommand::BackFromFormToTabs => {
-                    state.focus = PaneFocus::Tabs;
-                    continue;
-                }
-                HostGlobalCommand::BackToMemoriesTab => {
-                    if let Err(error) =
-                        switch_to_tab(provider, &mut state, hooks, KINIC_MEMORIES_TAB_ID)
-                    {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::CloseSettings => {
+                        show_settings = false;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::OpenCreateTab => {
-                    open_form_tab(provider, &mut state, hooks, KINIC_CREATE_TAB_ID, true);
-                    continue;
-                }
-                HostGlobalCommand::ToggleHelp => {
-                    show_help = true;
-                    continue;
-                }
-                HostGlobalCommand::ToggleChat => {
-                    if let Err(error) =
-                        dispatch_with_effects(provider, &mut state, hooks, &CoreAction::ToggleChat)
-                    {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::CloseChat => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleChat,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::ToggleSettings => {
-                    match dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::ToggleSettings,
-                    ) {
-                        Ok(()) => show_settings = true,
-                        Err(error) => state.status_message = Some(error),
+                    HostGlobalCommand::BackToTabs => {
+                        state.focus = PaneFocus::Tabs;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::SetDefaultFromSelection => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::SetDefaultMemoryFromSelection,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::BackFromFormToTabs => {
+                        state.focus = PaneFocus::Tabs;
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::OpenRenameMemory => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::OpenRenameMemory,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::BackToMemoriesTab => {
+                        if let Err(error) =
+                            switch_to_tab(provider, &mut state, hooks, KINIC_MEMORIES_TAB_ID)
+                        {
+                            state.status_message = Some(error);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::BackFromContent => {
-                    state.focus = PaneFocus::Items;
-                    continue;
-                }
-                HostGlobalCommand::BackFromItems => {
-                    state.focus = PaneFocus::Search;
-                    continue;
-                }
-                HostGlobalCommand::RefreshCurrentView => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::RefreshCurrentView,
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::OpenCreateTab => {
+                        open_form_tab(provider, &mut state, hooks, KINIC_CREATE_TAB_ID, true);
+                        continue;
                     }
-                    continue;
-                }
-                HostGlobalCommand::ClearQuery => {
-                    if let Err(error) = dispatch_with_effects(
-                        provider,
-                        &mut state,
-                        hooks,
-                        &CoreAction::SetQuery(String::new()),
-                    ) {
-                        state.status_message = Some(error);
+                    HostGlobalCommand::ToggleHelp => {
+                        show_help = true;
+                        continue;
                     }
-                    continue;
+                    HostGlobalCommand::ToggleChat => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleChat,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::ToggleSettings => {
+                        match dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::ToggleSettings,
+                        ) {
+                            Ok(()) => show_settings = true,
+                            Err(error) => state.status_message = Some(error),
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::SetDefaultFromSelection => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::SetDefaultMemoryFromSelection,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::OpenRenameMemory => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::OpenRenameMemory,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::BackFromContent => {
+                        state.focus = PaneFocus::Items;
+                        continue;
+                    }
+                    HostGlobalCommand::BackFromItems => {
+                        state.focus = PaneFocus::Search;
+                        continue;
+                    }
+                    HostGlobalCommand::RefreshCurrentView => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::RefreshCurrentView,
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::ClearQuery => {
+                        if let Err(error) = dispatch_with_effects(
+                            provider,
+                            &mut state,
+                            hooks,
+                            &CoreAction::SetQuery(String::new()),
+                        ) {
+                            state.status_message = Some(error);
+                        }
+                        continue;
+                    }
+                    HostGlobalCommand::Quit => break Ok(()),
                 }
-                HostGlobalCommand::Quit => break Ok(()),
             }
 
-            let action = form_tab_action_from_key(code, &mut state).or_else(|| {
-                if code == crossterm::event::KeyCode::Enter {
-                    if let Some(action) = selected_settings_row_behavior(&state)
-                        .and_then(|behavior| behavior.enter_action)
-                    {
-                        return Some(action);
+            let action = code.and_then(|code| {
+                form_tab_action_from_key(code, &mut state).or_else(|| {
+                    if code == crossterm::event::KeyCode::Enter {
+                        if let Some(action) = selected_settings_row_behavior(&state)
+                            .and_then(|behavior| behavior.enter_action)
+                        {
+                            return Some(action);
+                        }
                     }
-                }
-                action_from_keycode(code, state.focus, state.current_tab_id.as_str()).and_then(
-                    |a| {
-                        resolve_tab_action_with_current(
-                            a,
-                            tab_ids,
-                            Some(state.current_tab_id.as_str()),
-                        )
-                    },
-                )
+                    action_from_keycode(code, state.focus, state.current_tab_id.as_str()).and_then(
+                        |a| {
+                            resolve_tab_action_with_current(
+                                a,
+                                tab_ids,
+                                Some(state.current_tab_id.as_str()),
+                            )
+                        },
+                    )
+                })
             });
             let mut handled = false;
 
@@ -471,17 +523,7 @@ pub fn run_provider_app_with_hooks<P: DataProvider, H: RuntimeLoopHooks<P>>(
                     inspector_scroll = 0;
                 }
             }
-            if !handled
-                && hooks.on_unhandled_input(
-                    provider,
-                    &mut state,
-                    HostInputEvent {
-                        key_event,
-                        code,
-                        modifiers,
-                    },
-                )
-            {
+            if !handled && hooks.on_unhandled_input(provider, &mut state, input) {
                 continue;
             }
         }
@@ -561,7 +603,7 @@ fn build_ui<'a>(
     theme: &'a Theme,
     cfg: &RuntimeLoopConfig,
     state: &'a CoreState,
-    textareas: &FormTextareas,
+    textareas: &'a FormTextareas,
     list_scroll_offset: usize,
     inspector_scroll: usize,
     show_help: bool,
@@ -633,7 +675,7 @@ fn build_ui<'a>(
         .filtered_context_indices(&[])
         .candidates(&[])
         .chat_messages(&state.chat_messages)
-        .chat_input(&state.chat_input)
+        .chat_input(&textareas.chat_input.value)
         .chat_input_cursor(chat_input_cursor(
             active_textarea(state),
             &textareas.chat_input,
@@ -742,18 +784,28 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
     state: &mut CoreState,
     hooks: &mut H,
     textareas: &mut FormTextareas,
-    key_event: &crossterm::event::KeyEvent,
+    input: &HostInputEvent,
 ) -> Result<bool, Box<dyn std::error::Error>> {
+    if let Some(handled) = handle_chat_input_event(provider, state, hooks, textareas, input)? {
+        return Ok(handled);
+    }
+
     let Some(target) = active_textarea(state) else {
         return Ok(false);
     };
-    if target == ActiveTextarea::ChatInput
-        && handle_chat_command_navigation(state, textareas, key_event)
-    {
-        return Ok(true);
-    }
     let textarea = textarea_mut(textareas, target);
-    let action = textarea_navigation_action(target, key_event, key_event.code, textarea);
+    let HostInputEvent::Key {
+        key_event, code, ..
+    } = input
+    else {
+        textarea.insert_str(match input {
+            HostInputEvent::Paste(text) => text.as_str(),
+            HostInputEvent::Key { .. } => "",
+        });
+        sync_state_from_textareas(state, textareas);
+        return Ok(true);
+    };
+    let action = textarea_navigation_action(target, key_event, *code, textarea);
 
     let Some(action) = action else {
         if key_event.code == crossterm::event::KeyCode::Esc {
@@ -761,20 +813,8 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
         }
         textarea.input(textarea_input_from_key_event(*key_event));
         sync_state_from_textareas(state, textareas);
-        if target == ActiveTextarea::ChatInput {
-            sync_chat_textarea_from_state(
-                &mut textareas.chat_input,
-                state.chat_input.as_str(),
-                true,
-            );
-            sync_chat_command_selection(textareas, state.chat_input.as_str());
-        }
         return Ok(true);
     };
-
-    if target == ActiveTextarea::ChatInput && action == CoreAction::ChatSubmit {
-        return handle_chat_submit_or_command(provider, state, hooks, textareas);
-    }
 
     match dispatch_with_effects(provider, state, hooks, &action) {
         Ok(()) => Ok(true),
@@ -783,6 +823,82 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
             Ok(true)
         }
     }
+}
+
+fn handle_chat_input_event<P: DataProvider, H: RuntimeLoopHooks<P>>(
+    provider: &mut P,
+    state: &mut CoreState,
+    hooks: &mut H,
+    textareas: &mut FormTextareas,
+    input: &HostInputEvent,
+) -> Result<Option<bool>, Box<dyn std::error::Error>> {
+    if !chat_input_active(state) {
+        return Ok(None);
+    }
+
+    match input {
+        HostInputEvent::Paste(text) => {
+            insert_chat_text(
+                &mut textareas.chat_input,
+                flatten_chat_input_for_display(text).as_str(),
+            );
+            sync_state_from_chat_input(state, textareas);
+            Ok(Some(true))
+        }
+        HostInputEvent::Key {
+            key_event,
+            code,
+            modifiers,
+        } => {
+            if handle_chat_command_navigation(state, textareas, *code) {
+                return Ok(Some(true));
+            }
+            if let Some(action) = chat_input_action(*key_event, *code, *modifiers) {
+                return match action {
+                    ChatInputAction::Edit(edit) => {
+                        apply_chat_edit(&mut textareas.chat_input, edit);
+                        sync_state_from_chat_input(state, textareas);
+                        Ok(Some(true))
+                    }
+                    ChatInputAction::Submit => {
+                        handle_chat_submit_or_command(provider, state, hooks, textareas).map(Some)
+                    }
+                    ChatInputAction::Dispatch(core_action) => {
+                        match dispatch_with_effects(provider, state, hooks, &core_action) {
+                            Ok(()) => Ok(Some(true)),
+                            Err(error) => {
+                                state.status_message = Some(error);
+                                Ok(Some(true))
+                            }
+                        }
+                    }
+                    ChatInputAction::Passthrough => Ok(Some(false)),
+                };
+            }
+            Ok(Some(false))
+        }
+    }
+}
+
+fn handle_paste_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
+    provider: &mut P,
+    state: &mut CoreState,
+    hooks: &mut H,
+    text: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let normalized = flatten_single_line_paste(text);
+    if normalized.is_empty() {
+        return Ok(false);
+    }
+
+    if let Some(actions) = paste_actions_for_state(state, normalized.as_str()) {
+        for action in actions {
+            dispatch_with_effects(provider, state, hooks, &action).map_err(io::Error::other)?;
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
@@ -826,13 +942,13 @@ fn handle_chat_submit_or_command<P: DataProvider, H: RuntimeLoopHooks<P>>(
 fn handle_chat_command_navigation(
     state: &CoreState,
     textareas: &mut FormTextareas,
-    key_event: &crossterm::event::KeyEvent,
+    code: crossterm::event::KeyCode,
 ) -> bool {
     let matches = matching_slash_commands(state.chat_input.as_str());
     if matches.is_empty() {
         return false;
     }
-    match key_event.code {
+    match code {
         crossterm::event::KeyCode::Up => {
             if textareas.chat_command_selected == 0 {
                 textareas.chat_command_selected = matches.len().saturating_sub(1);
@@ -848,6 +964,103 @@ fn handle_chat_command_navigation(
         }
         _ => false,
     }
+}
+
+fn paste_actions_for_state(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    if state.access_control.open {
+        return paste_actions_for_access_control(state, text);
+    }
+    if state.add_memory.open {
+        return nonempty_actions(char_input_actions(text, CoreAction::AddMemoryInput));
+    }
+    if state.rename_memory.form.open {
+        return paste_actions_for_rename(state, text);
+    }
+    if state.transfer_modal.open {
+        return paste_actions_for_transfer(state, text);
+    }
+    if let PickerState::Input { .. } = &state.picker {
+        return nonempty_actions(char_input_actions(text, CoreAction::PickerInput));
+    }
+    if form_tab_flow::is_form_input_mode(state) && active_textarea(state).is_none() {
+        return nonempty_actions(form_paste_actions(state, text));
+    }
+    if state.focus == PaneFocus::Search {
+        return nonempty_actions(char_input_actions(text, CoreAction::SearchInput));
+    }
+
+    None
+}
+
+fn paste_actions_for_access_control(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::{AccessControlFocus, AccessControlMode};
+
+    if state.access_control.mode == AccessControlMode::Add
+        && state.access_control.focus == AccessControlFocus::Principal
+    {
+        return Some(char_input_actions(text, CoreAction::AccessInput));
+    }
+
+    None
+}
+
+fn paste_actions_for_transfer(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::{TransferModalFocus, TransferModalMode};
+
+    if state.transfer_modal.mode != TransferModalMode::Edit {
+        return None;
+    }
+
+    match state.transfer_modal.focus {
+        TransferModalFocus::Principal | TransferModalFocus::Amount => {
+            Some(char_input_actions(text, CoreAction::TransferInput))
+        }
+        TransferModalFocus::Max | TransferModalFocus::Submit => None,
+    }
+}
+
+fn paste_actions_for_rename(state: &CoreState, text: &str) -> Option<Vec<CoreAction>> {
+    use tui_kit_runtime::RenameModalFocus;
+
+    if state.rename_memory.focus == RenameModalFocus::Name {
+        return nonempty_actions(char_input_actions(text, CoreAction::RenameMemoryInput));
+    }
+
+    None
+}
+
+fn form_paste_actions(state: &CoreState, text: &str) -> Vec<CoreAction> {
+    let mut state_for_actions = state.clone();
+    text.chars()
+        .filter_map(|c| {
+            form_tab_flow::form_tab_action_from_key(
+                crossterm::event::KeyCode::Char(c),
+                &mut state_for_actions,
+            )
+        })
+        .collect()
+}
+
+fn char_input_actions(text: &str, action: impl Fn(char) -> CoreAction) -> Vec<CoreAction> {
+    text.chars().map(action).collect()
+}
+
+fn flatten_single_line_paste(text: &str) -> String {
+    canonicalize_paste_line_endings(text)
+        .lines()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn canonicalize_paste_line_endings(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn nonempty_actions(actions: Vec<CoreAction>) -> Option<Vec<CoreAction>> {
+    if actions.is_empty() {
+        return None;
+    }
+    Some(actions)
 }
 
 fn sync_chat_command_selection(textareas: &mut FormTextareas, input: &str) {
@@ -874,15 +1087,166 @@ fn chat_command_selection(state: &CoreState, textareas: &FormTextareas) -> Optio
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChatEdit {
+    MoveLeft,
+    MoveRight,
+    MoveHome,
+    MoveEnd,
+    Backspace,
+    Delete,
+    InsertChar(char),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ChatInputAction {
+    Edit(ChatEdit),
+    Submit,
+    Dispatch(CoreAction),
+    Passthrough,
+}
+
+#[cfg(test)]
+fn chat_edit_from_textarea_input(input: TextAreaInput) -> Option<ChatEdit> {
+    match input.key {
+        TextAreaKey::Char(c) if !input.ctrl && !input.alt => Some(ChatEdit::InsertChar(c)),
+        TextAreaKey::Left => Some(ChatEdit::MoveLeft),
+        TextAreaKey::Right => Some(ChatEdit::MoveRight),
+        TextAreaKey::Home => Some(ChatEdit::MoveHome),
+        TextAreaKey::End => Some(ChatEdit::MoveEnd),
+        TextAreaKey::Backspace => Some(ChatEdit::Backspace),
+        TextAreaKey::Delete => Some(ChatEdit::Delete),
+        _ => None,
+    }
+}
+
+fn chat_input_action(
+    _key_event: crossterm::event::KeyEvent,
+    code: crossterm::event::KeyCode,
+    modifiers: crossterm::event::KeyModifiers,
+) -> Option<ChatInputAction> {
+    match (code, modifiers) {
+        (crossterm::event::KeyCode::Tab, _) => {
+            Some(ChatInputAction::Dispatch(CoreAction::FocusNext))
+        }
+        (crossterm::event::KeyCode::BackTab, _) => {
+            Some(ChatInputAction::Dispatch(CoreAction::FocusPrev))
+        }
+        (crossterm::event::KeyCode::Enter, _) => Some(ChatInputAction::Submit),
+        (crossterm::event::KeyCode::Left, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+        }
+        (crossterm::event::KeyCode::Right, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+        }
+        (crossterm::event::KeyCode::PageUp, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::PageDown, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::Home, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+        {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::End, modifiers)
+            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
+        {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::Up, _) | (crossterm::event::KeyCode::Down, _) => {
+            Some(ChatInputAction::Passthrough)
+        }
+        (crossterm::event::KeyCode::Esc, _) => Some(ChatInputAction::Passthrough),
+        (crossterm::event::KeyCode::Left, _) => Some(ChatInputAction::Edit(ChatEdit::MoveLeft)),
+        (crossterm::event::KeyCode::Right, _) => Some(ChatInputAction::Edit(ChatEdit::MoveRight)),
+        (crossterm::event::KeyCode::Home, _) => Some(ChatInputAction::Edit(ChatEdit::MoveHome)),
+        (crossterm::event::KeyCode::End, _) => Some(ChatInputAction::Edit(ChatEdit::MoveEnd)),
+        (crossterm::event::KeyCode::Backspace, _) => {
+            Some(ChatInputAction::Edit(ChatEdit::Backspace))
+        }
+        (crossterm::event::KeyCode::Delete, _) => Some(ChatInputAction::Edit(ChatEdit::Delete)),
+        (crossterm::event::KeyCode::Char(c), modifiers)
+            if !c.is_control()
+                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
+                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
+        {
+            Some(ChatInputAction::Edit(ChatEdit::InsertChar(c)))
+        }
+        _ => None,
+    }
+}
+
+fn apply_chat_edit(chat_input: &mut ChatInputState, edit: ChatEdit) {
+    match edit {
+        ChatEdit::MoveLeft => {
+            chat_input.cursor_col = chat_input.cursor_col.saturating_sub(1);
+        }
+        ChatEdit::MoveRight => {
+            chat_input.cursor_col = (chat_input.cursor_col + 1).min(chat_input_len(chat_input));
+        }
+        ChatEdit::MoveHome => {
+            chat_input.cursor_col = 0;
+        }
+        ChatEdit::MoveEnd => {
+            chat_input.cursor_col = chat_input_len(chat_input);
+        }
+        ChatEdit::Backspace => {
+            if chat_input.cursor_col > 0 {
+                let remove_at = chat_input.cursor_col - 1;
+                let start = chat_input_byte_index(chat_input.value.as_str(), remove_at);
+                let end = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+                chat_input.value.replace_range(start..end, "");
+                chat_input.cursor_col = remove_at;
+            }
+        }
+        ChatEdit::Delete => {
+            let len = chat_input_len(chat_input);
+            if chat_input.cursor_col < len {
+                let start = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+                let end =
+                    chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col + 1);
+                chat_input.value.replace_range(start..end, "");
+            }
+        }
+        ChatEdit::InsertChar(c) => {
+            insert_chat_text(chat_input, c.to_string().as_str());
+        }
+    }
+}
+
+fn insert_chat_text(chat_input: &mut ChatInputState, text: &str) {
+    let insert_at = chat_input_byte_index(chat_input.value.as_str(), chat_input.cursor_col);
+    chat_input.value.insert_str(insert_at, text);
+    chat_input.cursor_col += text.chars().count();
+}
+
+fn chat_input_len(chat_input: &ChatInputState) -> usize {
+    chat_input.value.chars().count()
+}
+
+fn chat_input_byte_index(value: &str, char_index: usize) -> usize {
+    if char_index == 0 {
+        return 0;
+    }
+    value
+        .char_indices()
+        .nth(char_index)
+        .map(|(index, _)| index)
+        .unwrap_or(value.len())
+}
+
 fn textarea_navigation_action(
     target: ActiveTextarea,
-    key_event: &crossterm::event::KeyEvent,
+    _key_event: &crossterm::event::KeyEvent,
     code: crossterm::event::KeyCode,
     textarea: &TextArea<'static>,
 ) -> Option<CoreAction> {
-    if target == ActiveTextarea::ChatInput {
-        return chat_textarea_action(key_event, code);
-    }
     match code {
         crossterm::event::KeyCode::Tab => Some(textarea_next_field_action(target)),
         crossterm::event::KeyCode::BackTab => Some(textarea_prev_field_action(target)),
@@ -909,44 +1273,6 @@ fn textarea_prev_field_action(target: ActiveTextarea) -> CoreAction {
         ActiveTextarea::CreateDescription => CoreAction::CreatePrevField,
         ActiveTextarea::InsertText => CoreAction::InsertPrevField,
         ActiveTextarea::ChatInput => CoreAction::FocusPrev,
-    }
-}
-
-fn chat_textarea_action(
-    key_event: &crossterm::event::KeyEvent,
-    code: crossterm::event::KeyCode,
-) -> Option<CoreAction> {
-    match (code, key_event.modifiers) {
-        (crossterm::event::KeyCode::Tab, _) => Some(CoreAction::FocusNext),
-        (crossterm::event::KeyCode::BackTab, _) => Some(CoreAction::FocusPrev),
-        (crossterm::event::KeyCode::Enter, _) => Some(CoreAction::ChatSubmit),
-        (crossterm::event::KeyCode::Left, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
-                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
-        {
-            Some(CoreAction::ChatScopePrev)
-        }
-        (crossterm::event::KeyCode::Right, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::SHIFT)
-                && !modifiers.contains(crossterm::event::KeyModifiers::CONTROL)
-                && !modifiers.contains(crossterm::event::KeyModifiers::ALT) =>
-        {
-            Some(CoreAction::ChatScopeNext)
-        }
-        (crossterm::event::KeyCode::PageUp, _) => Some(CoreAction::ChatScrollPageUp),
-        (crossterm::event::KeyCode::PageDown, _) => Some(CoreAction::ChatScrollPageDown),
-        (crossterm::event::KeyCode::Home, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
-        {
-            Some(CoreAction::ChatScrollHome)
-        }
-        (crossterm::event::KeyCode::End, modifiers)
-            if modifiers.contains(crossterm::event::KeyModifiers::CONTROL) =>
-        {
-            Some(CoreAction::ChatScrollEnd)
-        }
-        _ => None,
     }
 }
 
@@ -979,7 +1305,7 @@ fn active_textarea(state: &CoreState) -> Option<ActiveTextarea> {
         return Some(ActiveTextarea::InsertText);
     }
 
-    if state.current_tab_id == KINIC_MEMORIES_TAB_ID && state.focus == PaneFocus::Extra {
+    if chat_input_active(state) {
         return Some(ActiveTextarea::ChatInput);
     }
 
@@ -990,7 +1316,7 @@ fn textarea_mut(textareas: &mut FormTextareas, target: ActiveTextarea) -> &mut T
     match target {
         ActiveTextarea::CreateDescription => &mut textareas.create_description,
         ActiveTextarea::InsertText => &mut textareas.insert_text,
-        ActiveTextarea::ChatInput => &mut textareas.chat_input,
+        ActiveTextarea::ChatInput => unreachable!("chat input no longer uses textarea"),
     }
 }
 
@@ -1000,7 +1326,7 @@ fn sync_form_textareas_from_state(textareas: &mut FormTextareas, state: &CoreSta
         state.create_description.as_str(),
     );
     sync_textarea_from_string(&mut textareas.insert_text, state.insert_text.as_str());
-    sync_chat_textarea_from_state(&mut textareas.chat_input, state.chat_input.as_str(), false);
+    sync_chat_input_from_state(&mut textareas.chat_input, state.chat_input.as_str());
 }
 
 fn sync_textarea_from_string(textarea: &mut TextArea<'static>, value: &str) {
@@ -1014,60 +1340,46 @@ fn textarea_from_text(value: &str) -> TextArea<'static> {
     TextArea::from(value.split('\n'))
 }
 
+#[cfg(test)]
+fn chat_input_from_text(value: &str) -> ChatInputState {
+    let single_line_value = flatten_chat_input_for_display(value);
+    ChatInputState {
+        cursor_col: single_line_value.chars().count(),
+        value: single_line_value,
+    }
+}
+
+fn chat_input_active(state: &CoreState) -> bool {
+    state.current_tab_id == KINIC_MEMORIES_TAB_ID && state.focus == PaneFocus::Extra
+}
+
 // Chat input is rendered and edited as a true single-line widget.
-fn chat_input_display_value(textarea: &TextArea<'static>) -> String {
-    textarea.lines().join("\n")
+fn chat_input_display_value(chat_input: &ChatInputState) -> String {
+    chat_input.value.clone()
 }
 
 fn chat_input_submit_value(value: &str) -> String {
     normalize_chat_input_lines(value)
 }
 
-fn chat_input_display_cursor_col(textarea: &TextArea<'static>) -> usize {
-    let lines = textarea.lines();
-    let last_row = lines.len().saturating_sub(1);
-    let (cursor_row, cursor_col) = textarea.cursor();
-    let effective_row = cursor_row.min(last_row);
-    let mut prefix_lines = lines
-        .iter()
-        .take(effective_row)
-        .map(|line| line.as_str().to_string())
-        .collect::<Vec<_>>();
-    let current_prefix = lines
-        .get(effective_row)
-        .map(|line| line.chars().take(cursor_col).collect::<String>())
-        .unwrap_or_default();
-    prefix_lines.push(current_prefix);
-    flatten_chat_input_for_display(prefix_lines.join("\n").as_str())
-        .chars()
-        .count()
-}
-
 fn chat_input_cursor(
     active: Option<ActiveTextarea>,
-    textarea: &TextArea<'static>,
+    chat_input: &ChatInputState,
 ) -> Option<(usize, usize)> {
     if active != Some(ActiveTextarea::ChatInput) {
         return None;
     }
-    Some((0, textarea.cursor().1))
+    Some((0, chat_input.cursor_col))
 }
 
-fn sync_chat_textarea_from_state(textarea: &mut TextArea<'static>, value: &str, preserve_cursor: bool) {
-    // Rebuild chat input from its flattened single-line form so pasted multiline
-    // content cannot leave hidden rows behind inside the widget.
+fn sync_chat_input_from_state(chat_input: &mut ChatInputState, value: &str) {
     let single_line_value = flatten_chat_input_for_display(value);
-    if textarea.lines().join("\n") == single_line_value {
+    if chat_input.value == single_line_value {
+        chat_input.cursor_col = chat_input.cursor_col.min(chat_input_len(chat_input));
         return;
     }
-    let cursor_col = if preserve_cursor {
-        chat_input_display_cursor_col(textarea).min(single_line_value.chars().count())
-    } else {
-        single_line_value.chars().count()
-    }
-    .min(u16::MAX as usize) as u16;
-    sync_textarea_from_string(textarea, single_line_value.as_str());
-    textarea.move_cursor(CursorMove::Jump(0, cursor_col));
+    chat_input.value = single_line_value;
+    chat_input.cursor_col = chat_input_len(chat_input);
 }
 
 fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
@@ -1089,11 +1401,18 @@ fn sync_state_from_textareas(state: &mut CoreState, textareas: &FormTextareas) {
         }
     }
 
-    let display_chat_input =
-        flatten_chat_input_for_display(textareas.chat_input.lines().join("\n").as_str());
+    let display_chat_input = chat_input_display_value(&textareas.chat_input);
     if state.chat_input != display_chat_input {
         state.chat_input = display_chat_input;
     }
+}
+
+fn sync_state_from_chat_input(state: &mut CoreState, textareas: &mut FormTextareas) {
+    let display_chat_input = chat_input_display_value(&textareas.chat_input);
+    if state.chat_input != display_chat_input {
+        state.chat_input = display_chat_input;
+    }
+    sync_chat_command_selection(textareas, state.chat_input.as_str());
 }
 
 fn textarea_cursor(

--- a/tui/crates/tui-kit-host/src/runtime_loop.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop.rs
@@ -798,10 +798,12 @@ fn handle_textarea_input<P: DataProvider, H: RuntimeLoopHooks<P>>(
         key_event, code, ..
     } = input
     else {
-        textarea.insert_str(match input {
-            HostInputEvent::Paste(text) => text.as_str(),
-            HostInputEvent::Key { .. } => "",
-        });
+        let pasted = match input {
+            // Keep multiline textarea paste aligned with other paste flows.
+            HostInputEvent::Paste(text) => canonicalize_paste_line_endings(text),
+            HostInputEvent::Key { .. } => String::new(),
+        };
+        textarea.insert_str(pasted.as_str());
         sync_state_from_textareas(state, textareas);
         return Ok(true);
     };

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -514,7 +514,7 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 }
 
 #[test]
-fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
+fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
     textareas.chat_input = textarea_from_text("first line\nsecond line");
@@ -525,7 +525,7 @@ fn chat_textarea_multiline_paste_keeps_raw_widget_with_normalized_state() {
     assert_eq!(state.chat_input, "first line second line");
     assert_eq!(
         textareas.chat_input.lines().join("\n"),
-        "first line\nsecond line"
+        "first line second line"
     );
 }
 
@@ -548,7 +548,7 @@ fn chat_textarea_display_value_preserves_trailing_space() {
     };
 
     assert_eq!(
-        normalized_chat_textarea_value(&textareas.chat_input),
+        chat_input_display_value(&textareas.chat_input),
         "hello "
     );
 }
@@ -601,10 +601,13 @@ fn chat_input_cursor_keeps_trailing_space_visible() {
 }
 
 #[test]
-fn chat_input_cursor_flattens_multiline_widget_position_for_ui() {
+fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
     let mut textarea = textarea_from_text("first line\nsecond line");
     textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
 
+    sync_chat_textarea_from_state(&mut textarea, "first line second line", true);
+
+    assert_eq!(textarea.lines().join("\n"), "first line second line");
     assert_eq!(
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
         Some((0, 17))
@@ -619,8 +622,167 @@ fn chat_textarea_display_value_keeps_space_before_next_char() {
     };
 
     assert_eq!(
-        normalized_chat_textarea_value(&textareas.chat_input),
+        chat_input_display_value(&textareas.chat_input),
         "hello w"
+    );
+}
+
+#[test]
+fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+
+    sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    let moved_up = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Up,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat up");
+    let cursor_after_up = textareas.chat_input.cursor();
+    let moved_down = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Down,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat down");
+
+    assert!(moved_up);
+    assert!(moved_down);
+    assert_eq!(cursor_after_up.0, 0);
+    assert_eq!(textareas.chat_input.cursor().0, 0);
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second line"
+    );
+}
+
+#[test]
+fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas {
+        chat_input: textarea_from_text("first line\nsecond line"),
+        ..FormTextareas::default()
+    };
+
+    sync_state_from_textareas(&mut state, &textareas);
+    sync_form_textareas_from_state(&mut textareas, &state);
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Home,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat home");
+    assert_eq!(textareas.chat_input.cursor(), (0, 0));
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::End,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat end");
+    assert_eq!(textareas.chat_input.cursor(), (0, 22));
+
+    handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Backspace,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat backspace");
+
+    assert_eq!(state.chat_input, "first line second lin");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second lin"
+    );
+    assert_eq!(textareas.chat_input.cursor(), (0, 21));
+}
+
+#[test]
+fn chat_textarea_midline_space_input_preserves_cursor_position() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        chat_input: "helloworld".to_string(),
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    sync_form_textareas_from_state(&mut textareas, &state);
+    for _ in 0..5 {
+        textareas.chat_input.input(textarea_input_from_key_event(
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Left,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        ));
+    }
+    let cursor_before = textareas.chat_input.cursor();
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char(' '),
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+    .expect("chat textarea input");
+
+    assert!(handled);
+    assert_eq!(cursor_before, (0, 5));
+    assert_eq!(state.chat_input, "hello world");
+    assert_eq!(textareas.chat_input.lines().join("\n"), "hello world");
+    assert_eq!(textareas.chat_input.cursor(), (0, 6));
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textareas.chat_input),
+        Some((0, 6))
     );
 }
 

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -406,6 +406,57 @@ fn textarea_input_updates_create_description_with_newlines() {
 }
 
 #[test]
+fn textarea_paste_normalizes_carriage_returns_in_create_description() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_CREATE_TAB_ID.to_string(),
+        focus: PaneFocus::Form,
+        create_focus: tui_kit_runtime::CreateModalFocus::Description,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("a\rb"),
+    )
+    .expect("textarea paste");
+
+    assert!(handled);
+    assert_eq!(state.create_description, "a\nb");
+}
+
+#[test]
+fn textarea_paste_normalizes_crlf_and_cr_in_insert_text() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_INSERT_TAB_ID.to_string(),
+        focus: PaneFocus::Form,
+        insert_mode: InsertMode::InlineText,
+        insert_focus: InsertFormFocus::Text,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("a\r\nb\rc"),
+    )
+    .expect("textarea paste");
+
+    assert!(handled);
+    assert_eq!(state.insert_text, "a\nb\nc");
+}
+
+#[test]
 fn textarea_up_on_first_create_description_row_moves_to_previous_field() {
     let mut provider = TestProvider::ok();
     let mut hooks = NoopRuntimeHooks;
@@ -739,6 +790,38 @@ fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
     assert_eq!(
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
         Some((0, 17))
+    );
+}
+
+#[test]
+fn chat_textarea_cursor_tracks_full_width_and_single_scalar_emoji() {
+    let mut textarea = chat_input_from_text("あいう🙂abc");
+
+    apply_chat_edit(&mut textarea, ChatEdit::MoveHome);
+    apply_chat_edit(&mut textarea, ChatEdit::MoveRight);
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 1))
+    );
+
+    apply_chat_edit(&mut textarea, ChatEdit::MoveEnd);
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, "あいう🙂abc".chars().count()))
+    );
+}
+
+#[test]
+#[ignore = "Complex Unicode grapheme handling is not implemented yet"]
+fn chat_textarea_cursor_treats_combining_sequence_as_single_step() {
+    let mut textarea = chat_input_from_text("e\u{301}x");
+
+    apply_chat_edit(&mut textarea, ChatEdit::MoveHome);
+    apply_chat_edit(&mut textarea, ChatEdit::MoveRight);
+
+    assert_eq!(
+        chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
+        Some((0, 2))
     );
 }
 

--- a/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
+++ b/tui/crates/tui-kit-host/src/runtime_loop_tests.rs
@@ -61,6 +61,21 @@ fn test_runtime_config() -> RuntimeLoopConfig {
     }
 }
 
+fn host_key(
+    code: crossterm::event::KeyCode,
+    modifiers: crossterm::event::KeyModifiers,
+) -> HostInputEvent {
+    HostInputEvent::Key {
+        key_event: crossterm::event::KeyEvent::new(code, modifiers),
+        code,
+        modifiers,
+    }
+}
+
+fn host_paste(text: &str) -> HostInputEvent {
+    HostInputEvent::Paste(text.to_string())
+}
+
 #[test]
 fn normalize_focus_keeps_memories_on_tabs_after_tab_switch() {
     let mut state = CoreState {
@@ -272,6 +287,84 @@ fn handle_overlay_input_consumes_unknown_selector_keys() {
 }
 
 #[test]
+fn paste_input_updates_search_query() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        focus: PaneFocus::Search,
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "alpha\nbeta")
+        .expect("search paste");
+
+    assert!(handled);
+    assert_eq!(state.query, "alpha beta");
+}
+
+#[test]
+fn paste_input_updates_rename_modal_name() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        rename_memory: RenameMemoryModalState {
+            form: TextInputModalState {
+                open: true,
+                ..TextInputModalState::default()
+            },
+            focus: tui_kit_runtime::RenameModalFocus::Name,
+            ..RenameMemoryModalState::default()
+        },
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "Alpha Memory")
+        .expect("rename paste");
+
+    assert!(handled);
+    assert_eq!(state.rename_memory.form.value, "Alpha Memory");
+}
+
+#[test]
+fn paste_input_normalizes_crlf_for_access_control_principal() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        access_control: tui_kit_runtime::AccessControlModalState {
+            open: true,
+            mode: tui_kit_runtime::AccessControlMode::Add,
+            focus: tui_kit_runtime::AccessControlFocus::Principal,
+            ..tui_kit_runtime::AccessControlModalState::default()
+        },
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "aaaa\r\nbbbb\rcccc")
+        .expect("access paste");
+
+    assert!(handled);
+    assert_eq!(state.access_control.principal_id, "aaaa bbbb cccc");
+}
+
+#[test]
+fn paste_input_updates_create_name_when_form_focus_is_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_CREATE_TAB_ID.to_string(),
+        focus: PaneFocus::Form,
+        create_focus: tui_kit_runtime::CreateModalFocus::Name,
+        ..CoreState::default()
+    };
+
+    let handled = handle_paste_input(&mut provider, &mut state, &mut hooks, "new memory")
+        .expect("create paste");
+
+    assert!(handled);
+    assert_eq!(state.create_name, "new memory");
+}
+
+#[test]
 fn textarea_input_updates_create_description_with_newlines() {
     let mut provider = TestProvider::ok();
     let mut hooks = NoopRuntimeHooks;
@@ -288,7 +381,7 @@ fn textarea_input_updates_create_description_with_newlines() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char('a'),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -301,7 +394,7 @@ fn textarea_input_updates_create_description_with_newlines() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -331,7 +424,7 @@ fn textarea_up_on_first_create_description_row_moves_to_previous_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -370,7 +463,7 @@ fn textarea_down_on_last_create_description_row_moves_to_submit() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -405,7 +498,7 @@ fn textarea_down_inside_insert_text_moves_cursor_before_leaving_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -443,7 +536,7 @@ fn textarea_down_on_last_insert_text_row_moves_to_next_field() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -473,7 +566,7 @@ fn chat_textarea_shift_enter_submits_instead_of_inserting_newline() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::SHIFT,
         ),
@@ -502,7 +595,7 @@ fn chat_textarea_enter_submits_without_inserting_text() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -515,13 +608,24 @@ fn chat_textarea_enter_submits_without_inserting_text() {
 
 #[test]
 fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
-    let mut state = CoreState::default();
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("first line\nsecond line");
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("first line\nsecond line"),
+    )
+    .expect("chat paste");
 
-    sync_state_from_textareas(&mut state, &textareas);
-    sync_form_textareas_from_state(&mut textareas, &state);
-
+    assert!(handled);
     assert_eq!(state.chat_input, "first line second line");
     assert_eq!(
         textareas.chat_input.lines().join("\n"),
@@ -530,10 +634,38 @@ fn chat_textarea_multiline_paste_normalizes_widget_and_state_to_single_line() {
 }
 
 #[test]
+fn chat_textarea_crlf_paste_normalizes_widget_and_state_to_single_line() {
+    let mut provider = TestProvider::ok();
+    let mut hooks = NoopRuntimeHooks;
+    let mut state = CoreState {
+        current_tab_id: KINIC_MEMORIES_TAB_ID.to_string(),
+        focus: PaneFocus::Extra,
+        ..CoreState::default()
+    };
+    let mut textareas = FormTextareas::default();
+    let handled = handle_textarea_input(
+        &mut provider,
+        &mut state,
+        &mut hooks,
+        &mut textareas,
+        &host_paste("first line\r\nsecond line\rthird line"),
+    )
+    .expect("chat paste");
+
+    assert!(handled);
+    assert_eq!(state.chat_input, "first line second line third line");
+    assert_eq!(
+        textareas.chat_input.lines().join("\n"),
+        "first line second line third line"
+    );
+    assert_eq!(textareas.chat_input.cursor(), (0, 33));
+}
+
+#[test]
 fn chat_textarea_sync_state_preserves_trailing_space() {
     let mut state = CoreState::default();
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
 
     sync_state_from_textareas(&mut state, &textareas);
 
@@ -543,20 +675,17 @@ fn chat_textarea_sync_state_preserves_trailing_space() {
 #[test]
 fn chat_textarea_display_value_preserves_trailing_space() {
     let textareas = FormTextareas {
-        chat_input: textarea_from_text("hello "),
+        chat_input: chat_input_from_text("hello "),
         ..FormTextareas::default()
     };
 
-    assert_eq!(
-        chat_input_display_value(&textareas.chat_input),
-        "hello "
-    );
+    assert_eq!(chat_input_display_value(&textareas.chat_input), "hello ");
 }
 
 #[test]
 fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget() {
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
     let state = CoreState {
         chat_input: "hello ".to_string(),
         ..CoreState::default()
@@ -570,7 +699,7 @@ fn chat_textarea_sync_from_state_preserves_equivalent_trailing_space_in_widget()
 #[test]
 fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
     let mut textareas = FormTextareas::default();
-    textareas.chat_input = textarea_from_text("hello ");
+    textareas.chat_input = chat_input_from_text("hello ");
     textareas.chat_input.input(textarea_input_from_key_event(
         crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Left,
@@ -591,8 +720,7 @@ fn chat_textarea_sync_from_state_keeps_cursor_when_text_is_unchanged() {
 
 #[test]
 fn chat_input_cursor_keeps_trailing_space_visible() {
-    let mut textarea = textarea_from_text("hello ");
-    textarea.move_cursor(ratatui_textarea::CursorMove::End);
+    let textarea = chat_input_from_text("hello ");
 
     assert_eq!(
         chat_input_cursor(Some(ActiveTextarea::ChatInput), &textarea),
@@ -602,10 +730,10 @@ fn chat_input_cursor_keeps_trailing_space_visible() {
 
 #[test]
 fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
-    let mut textarea = textarea_from_text("first line\nsecond line");
-    textarea.move_cursor(ratatui_textarea::CursorMove::Jump(1, 6));
+    let mut textarea = chat_input_from_text("first line\nsecond line");
+    textarea.cursor_col = 17;
 
-    sync_chat_textarea_from_state(&mut textarea, "first line second line", true);
+    sync_chat_input_from_state(&mut textarea, "first line second line");
 
     assert_eq!(textarea.lines().join("\n"), "first line second line");
     assert_eq!(
@@ -617,14 +745,11 @@ fn chat_textarea_input_normalization_keeps_cursor_on_display_column() {
 #[test]
 fn chat_textarea_display_value_keeps_space_before_next_char() {
     let textareas = FormTextareas {
-        chat_input: textarea_from_text("hello w"),
+        chat_input: chat_input_from_text("hello w"),
         ..FormTextareas::default()
     };
 
-    assert_eq!(
-        chat_input_display_value(&textareas.chat_input),
-        "hello w"
-    );
+    assert_eq!(chat_input_display_value(&textareas.chat_input), "hello w");
 }
 
 #[test]
@@ -637,7 +762,7 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
 
@@ -649,7 +774,7 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -661,15 +786,15 @@ fn chat_textarea_multiline_paste_up_down_do_not_move_hidden_rows() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
     )
     .expect("chat down");
 
-    assert!(moved_up);
-    assert!(moved_down);
+    assert!(!moved_up);
+    assert!(!moved_down);
     assert_eq!(cursor_after_up.0, 0);
     assert_eq!(textareas.chat_input.cursor().0, 0);
     assert_eq!(
@@ -688,7 +813,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
 
@@ -700,7 +825,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Home,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -713,7 +838,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::End,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -726,7 +851,7 @@ fn chat_textarea_multiline_paste_home_end_backspace_follow_visible_single_line()
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Backspace,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -768,7 +893,7 @@ fn chat_textarea_midline_space_input_preserves_cursor_position() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char(' '),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -804,7 +929,7 @@ fn chat_textarea_space_input_updates_state_and_widget_cursor() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Char(' '),
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -864,7 +989,7 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Down,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -878,7 +1003,7 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
         &mut state,
         &mut hooks,
         &mut textareas,
-        &crossterm::event::KeyEvent::new(
+        &host_key(
             crossterm::event::KeyCode::Up,
             crossterm::event::KeyModifiers::NONE,
         ),
@@ -891,83 +1016,109 @@ fn chat_textarea_up_down_moves_slash_command_selection() {
 
 #[test]
 fn chat_textarea_shift_arrows_switch_scope() {
-    let action_prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_prev = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Left,
             crossterm::event::KeyModifiers::SHIFT,
         ),
         crossterm::event::KeyCode::Left,
+        crossterm::event::KeyModifiers::SHIFT,
     );
-    let action_next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_next = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Right,
             crossterm::event::KeyModifiers::SHIFT,
         ),
         crossterm::event::KeyCode::Right,
+        crossterm::event::KeyModifiers::SHIFT,
     );
 
-    assert_eq!(action_prev, Some(CoreAction::ChatScopePrev));
-    assert_eq!(action_next, Some(CoreAction::ChatScopeNext));
+    assert_eq!(
+        action_prev,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+    );
+    assert_eq!(
+        action_next,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+    );
 }
 
 #[test]
 fn chat_textarea_shift_arrows_switch_scope_with_extra_modifier_bits() {
     let shift_super = crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::SUPER;
-    let prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Left, shift_super),
+    let prev = chat_input_action(
+        crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Left, shift_super),
         crossterm::event::KeyCode::Left,
+        shift_super,
     );
-    let next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Right, shift_super),
+    let next = chat_input_action(
+        crossterm::event::KeyEvent::new(crossterm::event::KeyCode::Right, shift_super),
         crossterm::event::KeyCode::Right,
+        shift_super,
     );
-    assert_eq!(prev, Some(CoreAction::ChatScopePrev));
-    assert_eq!(next, Some(CoreAction::ChatScopeNext));
+    assert_eq!(
+        prev,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopePrev))
+    );
+    assert_eq!(
+        next,
+        Some(ChatInputAction::Dispatch(CoreAction::ChatScopeNext))
+    );
 }
 
 #[test]
 fn chat_textarea_shift_arrow_with_control_or_alt_does_not_switch_scope() {
     assert_eq!(
-        chat_textarea_action(
-            &crossterm::event::KeyEvent::new(
+        chat_input_action(
+            crossterm::event::KeyEvent::new(
                 crossterm::event::KeyCode::Left,
                 crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::CONTROL,
             ),
             crossterm::event::KeyCode::Left,
+            crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::CONTROL,
         ),
-        None
+        Some(ChatInputAction::Edit(ChatEdit::MoveLeft))
     );
     assert_eq!(
-        chat_textarea_action(
-            &crossterm::event::KeyEvent::new(
+        chat_input_action(
+            crossterm::event::KeyEvent::new(
                 crossterm::event::KeyCode::Right,
                 crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::ALT,
             ),
             crossterm::event::KeyCode::Right,
+            crossterm::event::KeyModifiers::SHIFT | crossterm::event::KeyModifiers::ALT,
         ),
-        None
+        Some(ChatInputAction::Edit(ChatEdit::MoveRight))
     );
 }
 
 #[test]
 fn chat_textarea_brackets_remain_regular_input() {
-    let action_prev = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_prev = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char('['),
             crossterm::event::KeyModifiers::NONE,
         ),
         crossterm::event::KeyCode::Char('['),
+        crossterm::event::KeyModifiers::NONE,
     );
-    let action_next = chat_textarea_action(
-        &crossterm::event::KeyEvent::new(
+    let action_next = chat_input_action(
+        crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char(']'),
             crossterm::event::KeyModifiers::NONE,
         ),
         crossterm::event::KeyCode::Char(']'),
+        crossterm::event::KeyModifiers::NONE,
     );
 
-    assert_eq!(action_prev, None);
-    assert_eq!(action_next, None);
+    assert_eq!(
+        action_prev,
+        Some(ChatInputAction::Edit(ChatEdit::InsertChar('[')))
+    );
+    assert_eq!(
+        action_next,
+        Some(ChatInputAction::Edit(ChatEdit::InsertChar(']')))
+    );
 }
 
 #[test]
@@ -1051,7 +1202,7 @@ fn chat_submit_normalizes_multiline_input_before_sending_message() {
         ..CoreState::default()
     };
     let mut textareas = FormTextareas {
-        chat_input: textarea_from_text("first line\nsecond line"),
+        chat_input: chat_input_from_text("first line\nsecond line"),
         ..FormTextareas::default()
     };
     sync_state_from_textareas(&mut state, &textareas);

--- a/tui/crates/tui-kit-host/src/terminal.rs
+++ b/tui/crates/tui-kit-host/src/terminal.rs
@@ -10,8 +10,8 @@ use std::{
 
 use crossterm::{
     event::{
-        DisableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-        PushKeyboardEnhancementFlags,
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{
@@ -49,6 +49,7 @@ fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<bool> {
         execute!(
             terminal.backend_mut(),
             EnterAlternateScreen,
+            EnableBracketedPaste,
             PushKeyboardEnhancementFlags(
                 KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                     | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
@@ -56,7 +57,11 @@ fn enter_terminal(terminal: &mut HostTerminal) -> io::Result<bool> {
             )
         )?;
     } else {
-        execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+        execute!(
+            terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableBracketedPaste
+        )?;
     }
     terminal.hide_cursor()?;
     Ok(keyboard_enhancement_enabled)
@@ -72,12 +77,14 @@ fn leave_terminal(
         execute!(
             terminal.backend_mut(),
             PopKeyboardEnhancementFlags,
+            DisableBracketedPaste,
             LeaveAlternateScreen,
             DisableMouseCapture
         )?;
     } else {
         execute!(
             terminal.backend_mut(),
+            DisableBracketedPaste,
             LeaveAlternateScreen,
             DisableMouseCapture
         )?;

--- a/tui/crates/tui-kit-render/src/ui/app/screens/memories/cursor.rs
+++ b/tui/crates/tui-kit-render/src/ui/app/screens/memories/cursor.rs
@@ -157,4 +157,28 @@ mod tests {
                 .is_some()
         );
     }
+
+    #[test]
+    #[ignore = "Complex Unicode grapheme handling is not implemented yet"]
+    fn memories_chat_cursor_keeps_family_emoji_as_single_visible_cluster() {
+        let theme = Theme::default();
+        let ui = TuiKitUi::new(&theme)
+            .focus(Focus::Chat)
+            .show_chat(true)
+            .chat_input("👨‍👩‍👧‍👦a")
+            .chat_input_cursor(Some((0, 1)));
+
+        let first = ui
+            .memories_cursor_position_for_area(Rect::new(0, 0, 120, 40))
+            .expect("cursor after emoji cluster");
+        let second = TuiKitUi::new(&theme)
+            .focus(Focus::Chat)
+            .show_chat(true)
+            .chat_input("👨‍👩‍👧‍👦a")
+            .chat_input_cursor(Some((0, 2)))
+            .memories_cursor_position_for_area(Rect::new(0, 0, 120, 40))
+            .expect("cursor after following character");
+
+        assert!(second.0 > first.0);
+    }
 }

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -28,6 +28,7 @@ pub fn matching_slash_commands(input: &str) -> Vec<&'static str> {
         .collect()
 }
 
+/// Resolve a slash command from the normalized submit payload.
 pub fn chat_slash_command_action(input: &str) -> Option<CoreAction> {
     match input.trim() {
         "/new" => Some(CoreAction::ChatNewThread),
@@ -44,13 +45,14 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
         .and_then(chat_slash_command_action)
 }
 
-/// Collapse multiline chat input to one line for in-progress display.
+/// Collapse multiline chat input to one line for in-progress display and editing.
 /// This preserves user-typed spacing and only replaces line breaks with spaces.
 pub fn flatten_chat_input_for_display(value: &str) -> String {
     value.split('\n').collect::<Vec<_>>().join(" ")
 }
 
-/// Collapse multiline chat input to one line (trimmed lines joined with spaces).
+/// Collapse multiline chat input to the final submit/command-match form.
+/// Each line is trimmed before joining so pasted newlines do not leak layout-only spacing.
 pub fn normalize_chat_input_lines(value: &str) -> String {
     value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
 }

--- a/tui/crates/tui-kit-runtime/src/chat_commands.rs
+++ b/tui/crates/tui-kit-runtime/src/chat_commands.rs
@@ -48,13 +48,24 @@ pub fn selected_slash_command_action(input: &str, selected: usize) -> Option<Cor
 /// Collapse multiline chat input to one line for in-progress display and editing.
 /// This preserves user-typed spacing and only replaces line breaks with spaces.
 pub fn flatten_chat_input_for_display(value: &str) -> String {
-    value.split('\n').collect::<Vec<_>>().join(" ")
+    canonicalize_chat_line_endings(value)
+        .split('\n')
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Collapse multiline chat input to the final submit/command-match form.
 /// Each line is trimmed before joining so pasted newlines do not leak layout-only spacing.
 pub fn normalize_chat_input_lines(value: &str) -> String {
-    value.lines().map(str::trim).collect::<Vec<_>>().join(" ")
+    canonicalize_chat_line_endings(value)
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn canonicalize_chat_line_endings(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 #[cfg(test)]
@@ -75,7 +86,17 @@ mod tests {
     }
 
     #[test]
+    fn flatten_chat_input_for_display_normalizes_crlf_and_cr() {
+        assert_eq!(flatten_chat_input_for_display("a\r\nb\rc"), "a b c");
+    }
+
+    #[test]
     fn normalize_chat_input_lines_joins_trimmed_lines() {
         assert_eq!(normalize_chat_input_lines("a\n  b  \n c"), "a b c");
+    }
+
+    #[test]
+    fn normalize_chat_input_lines_handles_crlf_and_cr() {
+        assert_eq!(normalize_chat_input_lines("a\r\n  b \rc"), "a b c");
     }
 }

--- a/tui/crates/tui-kit-runtime/src/lib.rs
+++ b/tui/crates/tui-kit-runtime/src/lib.rs
@@ -27,6 +27,25 @@ pub const FILE_MODE_ALLOWED_EXTENSIONS: &[&str] = &[
     "md", "markdown", "mdx", "txt", "json", "yaml", "yml", "csv", "log", "pdf",
 ];
 
+/// Transfer amount accepts ASCII digits and a single decimal separator.
+/// Fractional precision is capped at 8 places to match ledger parsing.
+pub fn transfer_amount_accepts_char(current: &str, next: char) -> bool {
+    if next.is_ascii_digit() {
+        let fraction_len = current
+            .split_once('.')
+            .map_or(0, |(_, fraction)| fraction.chars().count());
+        return !current.contains('.') || fraction_len < 8;
+    }
+
+    next == '.' && !current.contains('.')
+}
+
+/// Principal-like identifiers in the TUI use lowercase text, digits, and hyphens.
+/// Final validity still belongs to `Principal::from_text(...)` at submit time.
+pub fn principal_text_accepts_char(next: char) -> bool {
+    next.is_ascii_lowercase() || next.is_ascii_digit() || next == '-'
+}
+
 /// Core result type used by provider and reducer contracts.
 pub type CoreResult<T> = Result<T, CoreError>;
 
@@ -1116,7 +1135,11 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             {
                 return;
             }
-            state.access_control.principal_id.push(*c);
+            if principal_text_accepts_char(*c) {
+                state.access_control.principal_id.push(*c);
+            } else {
+                return;
+            }
             clear_access_control_error(state);
         }
         CoreAction::AccessBackspace => {
@@ -1222,6 +1245,9 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
             close_add_memory_modal(state);
         }
         CoreAction::AddMemoryInput(c) => {
+            if !principal_text_accepts_char(*c) {
+                return;
+            }
             apply_text_input_modal_command(
                 &mut state.add_memory,
                 true,
@@ -1326,8 +1352,20 @@ pub fn apply_core_action(state: &mut CoreState, action: &CoreAction) {
                 return;
             }
             match state.transfer_modal.focus {
-                TransferModalFocus::Principal => state.transfer_modal.principal_id.push(*c),
-                TransferModalFocus::Amount => state.transfer_modal.amount.push(*c),
+                TransferModalFocus::Principal => {
+                    if principal_text_accepts_char(*c) {
+                        state.transfer_modal.principal_id.push(*c);
+                    } else {
+                        return;
+                    }
+                }
+                TransferModalFocus::Amount => {
+                    if transfer_amount_accepts_char(&state.transfer_modal.amount, *c) {
+                        state.transfer_modal.amount.push(*c);
+                    } else {
+                        return;
+                    }
+                }
                 TransferModalFocus::Max | TransferModalFocus::Submit => {}
             }
             clear_transfer_error(state);
@@ -4066,6 +4104,102 @@ mod tests {
 
         assert_eq!(state.transfer_modal.amount, "9.99900000");
         assert_eq!(state.transfer_modal.focus, TransferModalFocus::Submit);
+    }
+
+    #[test]
+    fn transfer_amount_input_rejects_non_numeric_characters() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Amount,
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        apply_core_action(&mut state, &CoreAction::TransferInput('1'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('x'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('.'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('2'));
+        apply_core_action(&mut state, &CoreAction::TransferInput('.'));
+
+        assert_eq!(state.transfer_modal.amount, "1.2");
+    }
+
+    #[test]
+    fn transfer_amount_input_caps_fractional_precision_at_eight_digits() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Amount,
+                amount: "0.".to_string(),
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "123456789".chars() {
+            apply_core_action(&mut state, &CoreAction::TransferInput(next));
+        }
+
+        assert_eq!(state.transfer_modal.amount, "0.12345678");
+    }
+
+    #[test]
+    fn transfer_principal_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            transfer_modal: TransferModalState {
+                open: true,
+                mode: TransferModalMode::Edit,
+                focus: TransferModalFocus::Principal,
+                ..TransferModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "abC-1_+".chars() {
+            apply_core_action(&mut state, &CoreAction::TransferInput(next));
+        }
+
+        assert_eq!(state.transfer_modal.principal_id, "ab-1");
+    }
+
+    #[test]
+    fn access_principal_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            access_control: AccessControlModalState {
+                open: true,
+                mode: AccessControlMode::Add,
+                focus: AccessControlFocus::Principal,
+                ..AccessControlModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "anonyMous!?-1".chars() {
+            apply_core_action(&mut state, &CoreAction::AccessInput(next));
+        }
+
+        assert_eq!(state.access_control.principal_id, "anonyous-1");
+    }
+
+    #[test]
+    fn add_memory_input_rejects_non_principal_characters() {
+        let mut state = CoreState {
+            add_memory: TextInputModalState {
+                open: true,
+                ..TextInputModalState::default()
+            },
+            ..CoreState::default()
+        };
+
+        for next in "aaaaA-aa\n_1".chars() {
+            apply_core_action(&mut state, &CoreAction::AddMemoryInput(next));
+        }
+
+        assert_eq!(state.add_memory.value, "aaaa-aa1");
     }
 
     #[test]


### PR DESCRIPTION
### Summary
- normalize terminal paste handling across chat, search, overlays, and multiline text inputs
- move the Memories chat input to a dedicated single-line state model so submit, shortcuts, and slash-command behavior stay consistent
- add bracketed paste support in the host input path and preserve pasted payloads explicitly
- validate principal and transfer-amount input in the runtime reducer, including decimal-point and precision limits for transfer amounts
- fix CRLF/CR normalization for textarea paste flows and improve chat cursor positioning for full-width characters and single-scalar emoji
- expand regression coverage and update TUI documentation for the new input behavior